### PR TITLE
Make enchant more portable

### DIFF
--- a/src/enchant.c
+++ b/src/enchant.c
@@ -2267,7 +2267,7 @@ enchant_get_prefix_dir(void)
 
 	if (!prefix) {
 		/* Use ENCHANT_PREFIX_DIR env var */
-		gchar* env = g_getenv("ENCHANT_PREFIX_DIR");
+		const gchar* env = g_getenv("ENCHANT_PREFIX_DIR");
 		if (env) {
 			prefix = g_filename_to_utf8(env, -1, NULL, NULL, NULL);
 		}

--- a/src/enchant.c
+++ b/src/enchant.c
@@ -2265,12 +2265,10 @@ enchant_get_prefix_dir(void)
 	}
 #endif
 
-#if defined(ENABLE_BINRELOC)
 	if (!prefix) {
-		/* Use standard binreloc PREFIX macro */
-		prefix = gbr_find_prefix(NULL);
+		/* Use ENCHANT_PREFIX_DIR env var */
+		prefix = g_strdup (g_getenv("ENCHANT_PREFIX_DIR"));
 	}
-#endif
 
 #if defined(ENCHANT_PREFIX_DIR)
 	if (!prefix) {

--- a/src/enchant.c
+++ b/src/enchant.c
@@ -2267,7 +2267,10 @@ enchant_get_prefix_dir(void)
 
 	if (!prefix) {
 		/* Use ENCHANT_PREFIX_DIR env var */
-		prefix = g_strdup (g_getenv("ENCHANT_PREFIX_DIR"));
+		gchar* env = g_getenv("ENCHANT_PREFIX_DIR");
+		if (env) {
+			prefix = g_filename_to_utf8(env, -1, NULL, NULL, NULL);
+		}
 	}
 
 #if defined(ENCHANT_PREFIX_DIR)

--- a/src/enchant.c
+++ b/src/enchant.c
@@ -240,7 +240,7 @@ enchant_get_module_dirs (void)
 
 #if defined(ENCHANT_GLOBAL_MODULE_DIR)
 	module_dirs = enchant_slist_append_unique_path (module_dirs, g_strdup (ENCHANT_GLOBAL_MODULE_DIR));
-#else
+#endif
 	/* Dynamically locate library and search for modules relative to it. */
 	prefix = enchant_get_prefix_dir();
 	if(prefix)
@@ -249,7 +249,6 @@ enchant_get_module_dirs (void)
 			g_free(prefix);
 			module_dirs = enchant_slist_append_unique_path (module_dirs, module_dir);
 		}
-#endif
 
 	return module_dirs;
 }


### PR DESCRIPTION
Always try to use enchant_get_prefix_dir when finding modules
Add environment variable to point enchant to a user defined prefix directory
