### PR TITLE
ispell improvements

### DIFF
--- a/tests/enchant-ispell.c
+++ b/tests/enchant-ispell.c
@@ -474,7 +474,19 @@ parse_file (FILE * in, FILE * out, IspellMode_t mode, int countLines, gchar *dic
 				case '`': /* Enter verbose-correction mode */
 					break;
 
-				/* FIXME: Implement aspell's $$ra <MISSPELLED>,<REPLACEMENT> using enchant_dict_store_replacement */
+				case '$': /* Save correction for rest of session [aspell extension] */
+					{ /* Syntax: $$ra <MISSPELLED>,<REPLACEMENT> */
+						gchar *prefix = "$$ra ";
+						if (g_str_has_prefix(str->str, prefix)) {
+							gchar *comma = g_utf8_strchr(str->str, -1, (gunichar)',');
+							char *mis = str->str + strlen(prefix);
+							char *cor = comma + 1;
+							ssize_t mis_len = comma - mis;
+							ssize_t cor_len = strlen(str->str) - (cor - str->str);
+							enchant_dict_store_replacement(dict, mis, mis_len, cor, cor_len);
+						}
+					}
+					break;
 
 				case '^': /* ^ is used as prefix to prevent interpretation of original
 					     first character as a command */

--- a/tests/enchant-ispell.c
+++ b/tests/enchant-ispell.c
@@ -348,7 +348,8 @@ tokenize_line (GString * line)
 	word = g_string_new (NULL);
 
 	while (cur_pos < line->len && *utf) {
-    int i;
+		int i;
+
 	        /* Skip non-word characters. */
 		cur_pos = g_utf8_pointer_to_offset ((const char*)line->str, utf);
 		uc = g_utf8_get_char (utf);

--- a/tests/enchant-ispell.c
+++ b/tests/enchant-ispell.c
@@ -438,7 +438,7 @@ parse_file (FILE * in, FILE * out, IspellMode_t mode, int countLines, gchar *dic
 			corrected_something = FALSE;
 
 			if (mode == MODE_A) {
-				switch ((int)*str->str) {
+				switch (*str->str) {
 				case '&': /* Insert uncapitalised in personal word list */
 					if (str->len > 1) {
 						gunichar c = g_utf8_get_char_validated(str->str + 1, str->len);

--- a/tests/enchant-ispell.c
+++ b/tests/enchant-ispell.c
@@ -327,7 +327,7 @@ convert_language_code (gchar *code)
 }
 
 
-/* Splits a line into a set of (word,word_position) touples. */
+/* Splits a line into a set of (word,word_position) tuples. */
 static GSList *
 tokenize_line (GString * line)
 {
@@ -368,7 +368,7 @@ tokenize_line (GString * line)
 			i--;
 		}
 
-		/* Save (word, position) touple. */
+		/* Save (word, position) tuple. */
                 if (word->len) {
 		        tokens = g_slist_append (tokens, g_string_new_len (word->str, word->len));
 			tokens = g_slist_append (tokens, GINT_TO_POINTER(start_pos));

--- a/tests/enchant-ispell.c
+++ b/tests/enchant-ispell.c
@@ -209,6 +209,10 @@ is_word_char (gunichar uc, size_t n)
 {
 	GUnicodeType type;
 
+	if (uc == g_utf8_get_char("'") || uc == g_utf8_get_char("’")) {
+		return 1;
+	}
+
 	type = g_unichar_type(uc);
 
 	switch (type) {
@@ -217,7 +221,7 @@ is_word_char (gunichar uc, size_t n)
 	case G_UNICODE_TITLECASE_LETTER:
 	case G_UNICODE_UPPERCASE_LETTER:
 	case G_UNICODE_OTHER_LETTER:
-	case G_UNICODE_COMBINING_MARK:
+	case G_UNICODE_COMBINING_MARK: /* Older name for G_UNICODE_SPACING_MARK; deprecated since glib 2.30 */
 	case G_UNICODE_ENCLOSING_MARK:
 	case G_UNICODE_NON_SPACING_MARK:
 	case G_UNICODE_DECIMAL_NUMBER:
@@ -226,12 +230,17 @@ is_word_char (gunichar uc, size_t n)
 	case G_UNICODE_CONNECT_PUNCTUATION:
                 return 1;     /* Enchant 1.3.0 defines word chars like this. */
 
+	case G_UNICODE_DASH_PUNCTUATION:
+		if ((n > 0) && (type == G_UNICODE_DASH_PUNCTUATION)) {
+			return 1; /* hyphens only accepted within a word. */
+		}
+		/* Fallthrough */
+
 	case G_UNICODE_CONTROL:
 	case G_UNICODE_FORMAT:
 	case G_UNICODE_UNASSIGNED:
 	case G_UNICODE_PRIVATE_USE:
 	case G_UNICODE_SURROGATE:
-	case G_UNICODE_DASH_PUNCTUATION:
 	case G_UNICODE_CLOSE_PUNCTUATION:
 	case G_UNICODE_FINAL_PUNCTUATION:
 	case G_UNICODE_INITIAL_PUNCTUATION:
@@ -245,13 +254,6 @@ is_word_char (gunichar uc, size_t n)
 	case G_UNICODE_PARAGRAPH_SEPARATOR:
 	case G_UNICODE_SPACE_SEPARATOR:
 	default:
-		if ((n > 0) && (uc == g_utf8_get_char("'"))) {
-		        return 1;  /** Char ' is accepted only within a word. */
-		}
-		else if ((n > 0) && (type == G_UNICODE_DASH_PUNCTUATION)) {
-			return 1; /* hyphens only accepted within a word. */
-		}
-
 		return 0;
 	}
 }


### PR DESCRIPTION
Add support for most ispell prefix commands, allowing programs such as Emacs
to use enchant as a full ispell replacement, adding words to the session
word list and personal word list.