### PR TITLE
Fix non-API const warnings

### DIFF
--- a/src/enchant.c
+++ b/src/enchant.c
@@ -830,9 +830,9 @@ enchant_dict_check (EnchantDict * dict, const char *const word, ssize_t len)
  */
 static int
 enchant_dict_merge_suggestions(EnchantDict * dict, 
-								const char ** suggs, 
+								char ** suggs,
 								size_t n_suggs,
-								const char * const* const new_suggs,
+								char ** new_suggs,
 								size_t n_new_suggs)
 {
 	size_t i, j;
@@ -871,7 +871,7 @@ enchant_dict_merge_suggestions(EnchantDict * dict,
 
 static char **
 enchant_dict_get_good_suggestions(EnchantDict * dict, 
-								const char * const* const suggs, 
+								char ** suggs,
 								size_t n_suggs,
 								size_t* out_n_filtered_suggs)
 {

--- a/src/pwl.c
+++ b/src/pwl.c
@@ -692,10 +692,10 @@ static void enchant_pwl_case_and_denormalize_suggestions(EnchantPWL *pwl,
 		}
 }
 
-static int best_distance(const char*const*const suggs, const char *const word, size_t len)
+static int best_distance(char** suggs, const char *const word, size_t len)
 {
 	int best_dist;
-	const char*const* sugg_it;
+	char** sugg_it;
 	char* normalized_word;
 
 	normalized_word = g_utf8_normalize (word, len, G_NORMALIZE_NFD);


### PR DESCRIPTION
This patch fixes those warnings that can be fixed without changing APIs.

The underlying principle is that since “const char” is not compatible with
“char”, it’s basically impossible to use “const” qualifiers sensibly for
objects that are allocated and freed.