### PR TITLE
Simplify finding provider modules in tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,7 @@ AC_HEADER_STDC
 LT_INIT([win32-dll])
 LT_LANG([Windows Resource])
 gl_INIT
-ENCHANT_LT_OBJDIR=$lt_cv_objdir
-AC_SUBST(ENCHANT_LT_OBJDIR)
+AC_SUBST([objdir])
 
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.6 gmodule-2.0])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,11 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/src $(ENCHANT_CFLAGS)
 
-# Note: give library directory with and without $(ENCHANT_LT_OBJDIR) to
-# work with static builds and on systems that do not have static compilation
-# and hence don't use LT_OBJDIR.
-# FIXME: Following line is not portable to MingW (need semicolons instead of colons)
 AM_TESTS_ENVIRONMENT = \
-	ENCHANT_MODULE_PATH=$(top_builddir)/providers/$(ENCHANT_LT_OBJDIR):$(top_builddir)/src/providers; \
+	ENCHANT_MODULE_PATH=$(top_builddir)/providers/@objdir@; \
 	export ENCHANT_MODULE_PATH; \
 	rm -f test.pwl; \
 	cp $(srcdir)/test.pwl.orig $(builddir)/test.pwl; \

--- a/unittests/Makefile.am
+++ b/unittests/Makefile.am
@@ -7,7 +7,7 @@ AM_TESTS_ENVIRONMENT = \
 	export ENCHANT_PREFIX_DIR; \
 	ENCHANT_CONFIG_DIR="config"; \
 	export ENCHANT_CONFIG_DIR; \
-	cp $(builddir)/mock_provider/*.so $(builddir)/mock_provider/.libs/*.so $(builddir)/mock_provider/*.dll $(builddir)/mock_provider/.libs/*.dll . || :;
+	cp $(builddir)/mock_provider/@objdir@/*.so $(builddir)/mock_provider/@objdir@/*.dll . || :;
 
 check_PROGRAMS = main
 TESTS = main


### PR DESCRIPTION
I had misunderstood the libtool documentation: LT_OBJDIR is always used for
dynamic objects. (Confirmed by reading the code.)

Also, the libtool variable objdir holds the same value, so AC_SUBST it
directly rather than inventing our own variable.

This also fixes an incompatibility with Windows for the integration test
environment (path separator).