### PR TITLE
Get AppleSpell back-end working again, and add list_dicts method

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,9 @@ ENCHANT_CHECK_PKG_CONFIG_PROVIDER([hunspell], [HUNSPELL])
 ENCHANT_CHECK_LIB_PROVIDER([aspell], [ASPELL], [get_aspell_dict_info_list])
 ENCHANT_CHECK_LIB_PROVIDER([hspell], [HSPELL], [hspell_get_dictionary_path],, [-lz])
 ENCHANT_CHECK_PKG_CONFIG_PROVIDER([voikko], [VOIKKO], [libvoikko])
-if test "$ac_cv_env_OBJCXX_value" != ""; then
+dnl FIXME: The test below assumes GCC(-compatible) ObjC++ compiler, but
+dnl OBJCXX is set even if no compiler is found.
+if test "$ac_cv_objcxx_compiler_gnu" = "yes"; then
   AC_LANG_PUSH([Objective C++])
   ENCHANT_CHECK_LIB_PROVIDER([applespell], [APPLESPELL], [NOLIB],, [-framework Cocoa], [Cocoa/Cocoa.h])
   AC_LANG_POP([Objective C++])

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -39,6 +39,7 @@ enchant_zemberek_la_SOURCES = enchant_zemberek.cpp
 
 if WITH_APPLESPELL
 provider_LTLIBRARIES += enchant_applespell.la
+pkgdata_DATA = AppleSpell.config
 endif
 enchant_applespell_la_LIBTOOLFLAGS = $(AM_LIBTOOLFLAGS) --tag=CXX
 enchant_applespell_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,15 +21,14 @@ endif
 libenchant_includedir = $(includedir)/enchant
 libenchant_include_HEADERS = enchant.h enchant-provider.h enchant++.h
 
-orderingdir=$(datadir)/enchant
-ordering_DATA = enchant.ordering
+pkgdata_DATA = enchant.ordering
 
 dist_man_MANS = enchant.1
 
 LDADD = libenchant.la $(ENCHANT_LIBS) $(top_builddir)/lib/libgnu.la
 bin_PROGRAMS = enchant-lsmod enchant
 
-EXTRA_DIST = $(ordering_DATA)
+EXTRA_DIST = $(pkgdata_DATA)
 
 .rc.lo:
 	$(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --tag=RC --mode=compile $(RC) $(RCFLAGS) $< -o $@

--- a/src/enchant-provider.h
+++ b/src/enchant-provider.h
@@ -31,6 +31,7 @@
 #define ENCHANT_PROVIDER_H
 
 #include <enchant.h>
+#include <glib.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -51,6 +52,7 @@ typedef struct str_enchant_provider EnchantProvider;
 char *enchant_get_user_language(void);
 
 char *enchant_get_user_config_dir (void);
+GSList *enchant_get_conf_dirs (void);
 
 /**
  * enchant_get_prefix_dir

--- a/src/lib.c
+++ b/src/lib.c
@@ -121,7 +121,7 @@ enchant_get_user_config_dir (void)
 	return g_build_filename (g_get_user_config_dir (), "enchant", NULL);
 }
 
-static GSList *
+GSList *
 enchant_get_conf_dirs (void)
 {
 	GSList *conf_dirs = NULL;


### PR DESCRIPTION
It transpired that owing to a problem in configure.ac, the backend was
not being built, even on macOS. Fix this.

As a result, some compilation errors recently introduced emerged. Fix
them.

Note that AppleSpell.config wasn't being installed. Fix this. Also fix
its loading: it was being looked for in pkglibdir, but should be
installed in pkgdatadir (and now is).

In order to find the config file, promote enchant_get_conf_dirs to
enchant-provider.h, which now therefore needs to include glib.h again.