### PR TITLE
Fix hunspell 1.5 support

### DIFF
--- a/providers/enchant_hunspell.cpp
+++ b/providers/enchant_hunspell.cpp
@@ -312,7 +312,7 @@ HunspellChecker::requestDictionary(const char *szLang)
 	if(hunspell == NULL){
 		return false;
 	}
-	char *enc = hunspell->get_dic_encoding();
+	const char *enc = hunspell->get_dic_encoding();
 
 	m_translate_in = g_iconv_open(enc, "UTF-8");
 	m_translate_out = g_iconv_open("UTF-8", enc);


### PR DESCRIPTION
We are carrying this patch in Gentoo for a while.

Originally reported in https://bugs.gentoo.org/show_bug.cgi?id=600952