### PR TITLE
configure.ac: += operator is not supported by POSIX shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ AC_DEFUN([ENCHANT_CHECK_PKG_CONFIG_PROVIDER],
       [PKG_CHECK_MODULES([$2], [m4_default([$3], [$1])],
          [$2[]_CFLAGS="$[]$2[]_CFLAGS -DENCHANT_[]$2[]_DICT_DIR='\"$[]$1_dir\"'"
          with_$1=yes
-         build_providers+=" $1"],
+         build_providers="$build_providers $1"],
          [if test "x$with_$1" != xcheck; then
             AC_MSG_FAILURE([--with-[]$1 was given, but test(s) for $1 failed])
           fi
@@ -260,7 +260,7 @@ AC_DEFUN([ENCHANT_CHECK_LIB_PROVIDER],
          with_[]$1=no
       else
          with_[]$1=yes
-         build_providers+=" $1"
+         build_providers="$build_providers $1"
          LIBS="$LIBS $5"
       fi])
    AM_CONDITIONAL(WITH_[]$2, test "x$with_[]$1" = xyes)])


### PR DESCRIPTION
Using `+=` operator in configure script causes all spell-checking providers to be disabled on FreeBSD.

```
checking for HUNSPELL... yes
/home/lantw44/gnome/source/enchant-2.2.0/configure: build_providers+= hunspell: not found
checking aspell.h usability... yes
checking aspell.h presence... yes
checking for aspell.h... yes
checking for get_aspell_dict_info_list in -laspell... yes
/home/lantw44/gnome/source/enchant-2.2.0/configure: build_providers+= aspell: not found
...
Providers to build:
configure: WARNING: No spell-checking provider selected!
```