### PR TITLE
Compute libdir_subdir for the tests properly (fixes issue #185)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
       env:
         - COMPILER=g++-5
     - os: osx
-      osx_image: xcode7.3
-    - os: osx
       osx_image: xcode9.2
     - compiler: gcc
       env:

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (Enchant) version 2018-01-15
+# bootstrap.conf (Enchant) version 2018-02-02
 
 # This file is part of Enchant.
 #
@@ -50,6 +50,7 @@ gnulib_modules='
         c99
         configmake
         flock
+        gnu-make
         manywarnings
         relocatable-lib-lgpl
         snippet/unused-parameter

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([enchant],[2.2.1])
+AC_INIT([enchant],[2.2.2])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects])
@@ -119,9 +119,6 @@ else
   ISYSTEM='-I'
 fi
 AC_SUBST([ISYSTEM])
-
-libdir_subdir=`echo "$libdir" | sed -e 's|^${exec_prefix}/||'`
-AC_SUBST([libdir_subdir])
 
 # FIXME: Use just GLIB_CFLAGS, GLIB_LIBS
 ENCHANT_CFLAGS=$GLIB_CFLAGS

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -56,3 +56,4 @@
 /rawmemchr.m4
 /strchrnul.m4
 /manywarnings-c++.m4
+/gnu-make.m4

--- a/m4/gnulib-cache.m4
+++ b/m4/gnulib-cache.m4
@@ -27,7 +27,7 @@
 
 
 # Specification in the form of a command-line invocation:
-#   gnulib-tool --import --local-dir=gl --local-dir=gl-mod/bootstrap --lib=libgnu --source-base=lib --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=build-aux --lgpl --makefile-name=Makefile.gnulib --no-conditional-dependencies --libtool --macro-prefix=gl bootstrap c99 configmake flock manywarnings relocatable-lib-lgpl snippet/unused-parameter ssize_t strchrnul strdup-posix valgrind-tests
+#   gnulib-tool --import --local-dir=gl --local-dir=gl-mod/bootstrap --lib=libgnu --source-base=lib --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=build-aux --lgpl --makefile-name=Makefile.gnulib --no-conditional-dependencies --libtool --macro-prefix=gl bootstrap c99 configmake flock gnu-make manywarnings relocatable-lib-lgpl snippet/unused-parameter ssize_t strchrnul strdup-posix valgrind-tests
 
 # Specification in the form of a few gnulib-tool.m4 macro invocations:
 gl_LOCAL_DIR([gl:gl-mod/bootstrap])
@@ -36,6 +36,7 @@ gl_MODULES([
   c99
   configmake
   flock
+  gnu-make
   manywarnings
   relocatable-lib-lgpl
   snippet/unused-parameter

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,12 @@
 SUBDIRS = enchant_providers
 
+# Get libdir suffix
+if !GNU_MAKE
+libdir_subdir=$(shell echo "$(libdir)" | sed -e 's|^$(exec_prefix)/||' | sed -e 's|^/||')
+else
+libdir_subdir=lib
+endif
+
 AM_CPPFLAGS = -I$(top_srcdir)/src $(ENCHANT_CFLAGS) -DENCHANT_MAJOR_VERSION=\"@ENCHANT_MAJOR_VERSION@\"
 
 ENCHANT_CONFIG_DIR = config

--- a/tests/enchant_providers/Makefile.am
+++ b/tests/enchant_providers/Makefile.am
@@ -1,5 +1,12 @@
 # FIXME: common up with tests/Makefile.am
 
+# Get libdir suffix
+if GNU_MAKE
+libdir_subdir=$(shell echo "$(libdir)" | sed -e 's|^$(exec_prefix)/||' | sed -e 's|^/||')
+else
+Tests require GNU Make!
+endif
+
 AM_CPPFLAGS = -I$(top_srcdir)/src $(ENCHANT_CFLAGS)
 
 ENCHANT_CONFIG_DIR = config


### PR DESCRIPTION
This is potentially nasty: the user who reported the issue noticed that the
tests tried to delete their system libraries!

Unfortunately, this requires setting a make variable from a shell
command (unless anyone has a better idea?).

This is not possible in POSIX make.

There is a suggestion to make it possible using the != assignment syntax,
which is already widely supported, but unfortunately automake rejects that
syntax.

Therefore, use $(shell), and use the gnu-make gnulib module to detect GNU
Make; if it is not being used, try setting libdir_subdir=lib, which will
work with default settings.

Document this requirement in INSTALL.