### PR TITLE
Attempt to support case-sensitive search

### DIFF
--- a/src/enchant.h
+++ b/src/enchant.h
@@ -164,6 +164,20 @@ void enchant_broker_describe (EnchantBroker * broker,
 int enchant_dict_check (EnchantDict * dict, const char *const word, ssize_t len);
 
 /**
+ * enchant_dict_check
+ * @dict: A non-null #EnchantDict
+ * @word: The non-null word you wish to check, in UTF-8 encoding
+ * @len: The byte length of @word, or -1 for strlen (@word)
+ *
+ * Will return an "incorrect" value if any of those pre-conditions
+ * are not met.
+ * Does not attempt to search for titlecase/lowercase variations of @word.
+ *
+ * Returns: 0 if the word is correctly spelled, positive if not, negative if error
+ */
+int enchant_dict_check_case_sensitive (EnchantDict * dict, const char *const word, ssize_t len)
+
+/**
  * enchant_dict_suggest
  * @dict: A non-null #EnchantDict
  * @word: The non-null word you wish to find suggestions for, in UTF-8 encoding

--- a/src/lib.c
+++ b/src/lib.c
@@ -359,8 +359,8 @@ enchant_session_exclude (EnchantSession * session, const char * const word, size
 	gboolean result = !g_hash_table_lookup (session->session_include, utf) &&
 		(g_hash_table_lookup (session->session_exclude, utf) ||
 		 (normalize_case ?
-			enchant_pwl_check (session->exclude, word, len) == 0) :
-			enchant_pwl_contains (session->exclude, word, len) == 0);
+			(enchant_pwl_check (session->exclude, word, len) == 0) :
+			(enchant_pwl_contains (session->exclude, word, len) == 0));
 	g_free (utf);
 
 	return result;


### PR DESCRIPTION
@hfiguiere Would really appreciate if you could take a look at this. I tried adding support for a new `enchant_dict_check_case_sensitive` method that would not break compatibility by altering the existing overload, so wrapper libraries like PyEnchant should be able to amend their API to something like

```py
dict.check('word'[, case_sensitive=False])
```

Fixes https://github.com/AbiWord/enchant/issues/189