### PR TITLE
Fix #193: move instructions for building from git to HACKING

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -4,7 +4,17 @@
 Building from git
 -----------------
 
-See INSTALL.
+To build from git, or without relying on the generated files in a source
+release, automake, autoconf, libtool, pkg-config and git must be installed.
+Run
+
+./bootstrap && ./configure --enable-relocatable
+
+to set up and configure the source tree; optional configure arguments can be
+supplied as normal.
+
+See INSTALL (which is created by bootstrap) for instructions from this point
+on.
 
 
 Working in libenchant

--- a/gl/doc/INSTALL.diff
+++ b/gl/doc/INSTALL.diff
@@ -1,6 +1,6 @@
 --- gnulib/doc/INSTALL	2017-02-23 15:26:15.296354123 +0000
 +++ INSTALL	2017-12-08 15:38:22.819949859 +0000
-@@ -1,3 +1,59 @@
+@@ -1,3 +1,52 @@
 +Building and installing libenchant
 +**********************************
 +
@@ -17,14 +17,7 @@
 +Building from git
 +=================
 +
-+To build from git, or without relying on the generated files in a source
-+release, automake, autoconf, libtool, pkg-config and git must be installed.
-+Run
-+
-+./bootstrap && ./configure --enable-relocatable
-+
-+to set up and configure the source tree; optional configure arguments can be
-+supplied as normal.
++See HACKING.
 +
 +
 +Parallel installation


### PR DESCRIPTION
INSTALL is not in git, so having HACKING refer to it was unhelpful. Thanks
to @asmeurer for the report.