### PR TITLE
configure.ac: Remove an unnecessary 'p'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ if test "$gl_gcc_warnings" = yes; then
   dnl gl_WARN_ADD([-fsanitize=address])
   dnl gl_WARN_ADD([-fsanitize=address], [AM_LDFLAGS])
   dnl dnl Enable undefined behavior checking
-p  dnl gl_WARN_ADD([-fsanitize=undefined])
+  dnl gl_WARN_ADD([-fsanitize=undefined])
   dnl gl_WARN_ADD([-fsanitize=undefined], [AM_LDFLAGS])
 
   # When compiling with GCC, prefer -isystem to -I when including system


### PR DESCRIPTION
This fixes an error message showed during configure:
```
checking whether C compiler handles -Wstrict-overflow=1... yes
checking whether C compiler handles -D_FORTIFY_SOURCE=2... yes
checking whether C compiler handles -Wno-error=format-security... yes
/home/lantw44/gnome/source/enchant-2.2.3/configure: p: not found
```