### PR TITLE
Avoid possible `rm -rf /` when running `make check`

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,7 +33,7 @@ $(LIBENCHANT_COPY): $(top_builddir)/src/libenchant-@ENCHANT_MAJOR_VERSION@.la
 	$(MAKE) libenchant-copy
 
 libenchant-copy:
-	rm -rf $(libdir_subdir)/
+	rm -rf $(libdir_subdir)
 	$(MKDIR_P) $(libdir_subdir)/enchant-@ENCHANT_MAJOR_VERSION@
 	cp -r $(top_builddir)/src/@objdir@ $(libdir_subdir)/
 	cp $(top_builddir)/src/libenchant-@ENCHANT_MAJOR_VERSION@.la $(libdir_subdir)/

--- a/tests/enchant_providers/Makefile.am
+++ b/tests/enchant_providers/Makefile.am
@@ -28,7 +28,7 @@ $(LIBENCHANT_COPY): $(top_builddir)/src/libenchant-@ENCHANT_MAJOR_VERSION@.la
 	$(MAKE) libenchant-copy
 
 libenchant-copy:
-	rm -rf $(libdir_subdir)/
+	rm -rf $(libdir_subdir)
 	$(MKDIR_P) $(libdir_subdir)/enchant-@ENCHANT_MAJOR_VERSION@
 	cp -r $(top_builddir)/src/@objdir@ $(libdir_subdir)/
 	cp $(top_builddir)/src/libenchant-@ENCHANT_MAJOR_VERSION@.la $(libdir_subdir)/


### PR DESCRIPTION
- Always avoid trailing slash in `rm -rf $(var)/'. When `$(var)' is not
  initialized this can ends up in `rm -rf /'.  The trailing slash
  is not needed and can be just avoided.
- Avoid GNU_MAKE usage.
- Conditionalize WITH_APPLESPELL logic in tests for targets that are used
  only when WITH_APPLESPELL is defined.

This fixes #201 and probably also fixes #185.