### PR TITLE
Mention Common Lisp interface and URL in README

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,7 @@ for:
 Python: https://github.com/rfk/pyenchant/
 Ruby: https://github.com/pennyapp/ruby-enchant
 Go: http://pythonhosted.org/pyenchant/
+Common Lisp: https://github.com/tlikonen/cl-enchant
 
 
 Sharing personal word lists between spell-checkers


### PR DESCRIPTION
I am the author of Common Lisp programming interface for Enchant C library. The Common Lisp interface has been available in the Quicklisp package distribution for some years.