### PR TITLE
Provider tests: use user’s default language first if possible (fix #231)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,4 @@ script:
   - ./configure --enable-relocatable --with-zemberek=check "${CONFIGURE_ARGS[@]}"
   - make
   - make distcheck
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo locale-gen fr_FR.UTF-8; env LANG=fr_FR.UTF-8 make check ; fi

--- a/tests/enchant_providers/Dictionary/dictionary_check.cpp
+++ b/tests/enchant_providers/Dictionary/dictionary_check.cpp
@@ -36,7 +36,7 @@ struct DictionaryCheck_TestFixture : Provider_TestFixture
     //Setup
     DictionaryCheck_TestFixture():_dict(NULL)
     { 
-        _dict = GetFirstAvailableDictionary();
+        _dict = GetDefaultDictionary();
         /* FIXME: hspell does not consider non-Hebrew letters to be valid letters */
         if (_dict) {
           _provider_name = _provider->identify(_provider);

--- a/tests/enchant_providers/Dictionary/dictionary_suggest.cpp
+++ b/tests/enchant_providers/Dictionary/dictionary_suggest.cpp
@@ -32,7 +32,7 @@ struct DictionarySuggest_TestFixture : Provider_TestFixture
     //Setup
     DictionarySuggest_TestFixture():_dict(NULL)
     { 
-        _dict = GetFirstAvailableDictionary();
+        _dict = GetDefaultDictionary();
     }
 
     //Teardown

--- a/tests/enchant_providers/unittest_enchant_providers.h
+++ b/tests/enchant_providers/unittest_enchant_providers.h
@@ -63,12 +63,20 @@ struct Provider_TestFixture
         return ws;
     }
 
-    EnchantDict* GetFirstAvailableDictionary()
+    EnchantDict* GetDefaultDictionary()
     {
         EnchantDict* dict=NULL;        
 
-        // get the first dictionary listed as being available
-        if(_provider->list_dicts && _provider->request_dict)
+        // Try getting dictionary for user's default language
+        char *lang = enchant_get_user_language();
+        if (_provider->request_dict)
+        {
+                dict = (*_provider->request_dict) (_provider, lang);
+        }
+        g_free (lang);
+
+        // If not available, get the first dictionary listed as being available
+        if (!dict && _provider->list_dicts && _provider->request_dict)
         {
                 size_t n_dicts;
 


### PR DESCRIPTION
Also run tests with both en_US and fr_FR on Travis.