### PR TITLE
Fix back-ends that want a NUL-terminated string (fix #259)

### DIFF
--- a/providers/enchant_voikko.c
+++ b/providers/enchant_voikko.c
@@ -48,9 +48,11 @@
  */
 
 static int
-voikko_dict_check (EnchantDict * me, const char *const word, size_t len _GL_UNUSED_PARAMETER)
+voikko_dict_check (EnchantDict * me, const char *const word, size_t len)
 {
-	int result = voikkoSpellCstr((struct VoikkoHandle *)me->user_data, word);
+	char *word_nul = strndup(word, len);
+	int result = voikkoSpellCstr((struct VoikkoHandle *)me->user_data, word_nul);
+	free(word_nul);
 	if (result == VOIKKO_SPELL_FAILED)
 		return 1;
 	else if (result == VOIKKO_SPELL_OK)
@@ -61,9 +63,11 @@ voikko_dict_check (EnchantDict * me, const char *const word, size_t len _GL_UNUS
 
 static char **
 voikko_dict_suggest (EnchantDict * me, const char *const word,
-		     size_t len _GL_UNUSED_PARAMETER, size_t * out_n_suggs)
+		     size_t len, size_t * out_n_suggs)
 {
-	char **voikko_sugg_arr = voikkoSuggestCstr((struct VoikkoHandle *)me->user_data, word);
+	char *word_nul = strndup(word, len);
+	char **voikko_sugg_arr = voikkoSuggestCstr((struct VoikkoHandle *)me->user_data, word_nul);
+	free(word_nul);
 	if (voikko_sugg_arr == NULL)
 		return NULL;
 	for (*out_n_suggs = 0; voikko_sugg_arr[*out_n_suggs] != NULL; (*out_n_suggs)++);

--- a/providers/enchant_zemberek.cpp
+++ b/providers/enchant_zemberek.cpp
@@ -142,18 +142,24 @@ extern "C" {
 EnchantProvider *init_enchant_provider(void);
 
 static int
-zemberek_dict_check (EnchantDict * me, const char *const word, size_t len _GL_UNUSED_PARAMETER)
+zemberek_dict_check (EnchantDict * me, const char *const word, size_t len)
 {
     Zemberek *checker = (Zemberek *) me->user_data;
-    return checker->checkWord(word);
+    char *word_nul = g_strndup(word, len);
+    int result = checker->checkWord(word_nul);
+    free(word_nul);
+    return result;
 }
 
 static char**
 zemberek_dict_suggest (EnchantDict * me, const char *const word,
-                       size_t len _GL_UNUSED_PARAMETER, size_t * out_n_suggs)
+                       size_t len, size_t * out_n_suggs)
 {
     Zemberek *checker = (Zemberek *) me->user_data;
-    return checker->suggestWord (word, out_n_suggs);
+    char *word_nul = g_strndup(word, len);
+    char **result = checker->suggestWord(word_nul, out_n_suggs);
+    free(word_nul);
+    return result;
 }
 
 static void


### PR DESCRIPTION
Voikko and Zemberek’s APIs assume a NUL-terminated string. Enchant does not
guarantee to provide one, so copy and NUL-terminate the provided string in
the check methods.