### PR TITLE
Make Aspell the default backend for English locales it supports

### DIFF
--- a/src/enchant.ordering
+++ b/src/enchant.ordering
@@ -1,4 +1,9 @@
 *:hunspell,nuspell,aspell
+en:aspell,hunspell,nuspell
+en_AU:aspell,hunspell,nuspell
+en_CA:aspell,hunspell,nuspell
+en_GB:aspell,hunspell,nuspell
+en_US:aspell,hunspell,nuspell
 fi:voikko,hunspell,nuspell,aspell
 fi_FI:voikko,hunspell,nuspell,aspell
 he:hspell,hunspell,nuspell


### PR DESCRIPTION
The data at http://aspell.net/test/common-all-all/ indicates that Aspell is much quicker than Hunspell and achieves slightly better results.

Fixes #270.