### PR TITLE
Update nuspell in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,9 +24,13 @@ for:
     only:
       - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
   init:
-    - sudo add-apt-repository -y ppa:nuspell/ppa
     - sudo apt-get -y update && sudo apt-get -y upgrade
-    - sudo apt-get -y install libglib2.0-dev libaspell-dev hspell libhunspell-dev libvoikko-dev voikko-fi aspell-en libunittest++-dev hunspell-fr libnuspell-dev
+    - sudo apt-get -y install libglib2.0-dev libaspell-dev hspell libhunspell-dev libvoikko-dev voikko-fi aspell-en libunittest++-dev hunspell-fr libicu-dev ninja-build
+    - wget https://github.com/nuspell/nuspell/archive/refs/tags/v5.0.0.tar.gz -O - | tar -xz
+    - cmake -S nuspell-* -B nuspell-build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=0
+    - cmake --build nuspell-build
+    - sudo cmake --install nuspell-build
+    - rm -rf nuspell-*
   build_script:
     - export ASAN
     - ./build-aux/appveyor-build.sh


### PR DESCRIPTION
Updates nuspell in CI. Instead of the ppa, Nuspell is built and installed from source since the ppa is not updated and I don't plan on updating it.

