### PR TITLE
Reduce dependency on gnulib by requiring C99 and POSIX 2008

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (Enchant) version 2020-01-18
+# bootstrap.conf (Enchant) version 2022-03-19
 
 # This file is part of Enchant.
 #
@@ -47,17 +47,12 @@ gnulib_tool_options='
 # gnulib modules used by this package.
 gnulib_modules='
         bootstrap
-        c99
         configmake
         flock
-        getopt-posix
         gnu-make
         manywarnings
         relocatable-lib-lgpl
-        snippet/unused-parameter
         strchrnul
-        strdup-posix
-        ssize_t
 '
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,9 @@ AC_SUBST(ENCHANT_MINOR_VERSION)
 AC_SUBST(ENCHANT_MICRO_VERSION)
 
 dnl Checks for programs.
-AC_PROG_CC
+AC_PROG_CC_C99
+AS_IF([test "$ac_cv_prog_cc_c99" = no],
+  AC_MSG_ERROR([A C99 or later compiler is required]))
 gl_EARLY
 AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX(11)

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -43,3 +43,4 @@
 /getopt1.c
 /getopt_int.h
 /gettext.h
+/dummy.c

--- a/providers/enchant_aspell.c
+++ b/providers/enchant_aspell.c
@@ -42,7 +42,6 @@
 #include <aspell.h>
 
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 
 EnchantProvider *init_enchant_provider (void);
@@ -132,7 +131,7 @@ aspell_dict_store_replacement (EnchantDict * me,
 }
 
 static EnchantDict *
-aspell_provider_request_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, const char *const tag)
+aspell_provider_request_dict (EnchantProvider * me _GL_UNUSED, const char *const tag)
 {
 	AspellConfig *spell_config = new_aspell_config ();
 	aspell_config_replace (spell_config, "language-tag", tag);
@@ -162,7 +161,7 @@ aspell_provider_request_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, const c
 }
 
 static void
-aspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, EnchantDict * dict)
+aspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED, EnchantDict * dict)
 {
 	AspellSpeller *manager = (AspellSpeller *) dict->user_data;
 	delete_aspell_speller (manager);
@@ -171,7 +170,7 @@ aspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, Enchant
 }
 
 static char **
-aspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
+aspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 			    size_t * out_n_dicts)
 {
 	AspellConfig * spell_config = new_aspell_config ();
@@ -213,13 +212,13 @@ aspell_provider_dispose (EnchantProvider * me)
 }
 
 static const char *
-aspell_provider_identify (EnchantProvider * me _GL_UNUSED_PARAMETER)
+aspell_provider_identify (EnchantProvider * me _GL_UNUSED)
 {
 	return "aspell";
 }
 
 static const char *
-aspell_provider_describe (EnchantProvider * me _GL_UNUSED_PARAMETER)
+aspell_provider_describe (EnchantProvider * me _GL_UNUSED)
 {
 	return "Aspell Provider";
 }

--- a/providers/enchant_hspell.c
+++ b/providers/enchant_hspell.c
@@ -43,7 +43,6 @@
 #include <hspell.h>
 
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 /**
  * convert struct corlist to **char
@@ -147,7 +146,7 @@ hspell_provider_request_dict (EnchantProvider * me, const char *const tag)
 }
 
 static void
-hspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, EnchantDict * dict)
+hspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED, EnchantDict * dict)
 {
 	struct dict_radix *hspell_dict = (struct dict_radix *)dict->user_data;
 	hspell_uninit (hspell_dict);
@@ -157,7 +156,7 @@ hspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, Enchant
 /* test for the existence of, then return $prefix/share/hspell/hebrew.wgz */
 
 static char **
-hspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
+hspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 			    size_t * out_n_dicts)
 {
 	const char * dictionary_path = hspell_get_dictionary_path();
@@ -187,13 +186,13 @@ hspell_provider_dispose (EnchantProvider * me)
 }
 
 static const char *
-hspell_provider_identify (EnchantProvider * me _GL_UNUSED_PARAMETER)
+hspell_provider_identify (EnchantProvider * me _GL_UNUSED)
 {
 	return "hspell";
 }
 
 static const char *
-hspell_provider_describe (EnchantProvider * me _GL_UNUSED_PARAMETER)
+hspell_provider_describe (EnchantProvider * me _GL_UNUSED)
 {
 	return "Hspell Provider";
 }

--- a/providers/enchant_hunspell.cpp
+++ b/providers/enchant_hunspell.cpp
@@ -43,7 +43,6 @@
 #include <vector>
 
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 #include <hunspell/hunspell.hxx>
 // hunspell itself uses this definition (which only supports the BMP)
@@ -411,7 +410,7 @@ hunspell_provider_enum_dicts (const char * const directory,
 extern "C" {
 
 static char **
-hunspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
+hunspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 			      size_t * out_n_dicts)
 {
 	std::vector<std::string> dict_dirs, dicts;
@@ -436,7 +435,7 @@ hunspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
 }
 
 static EnchantDict *
-hunspell_provider_request_dict(EnchantProvider * me _GL_UNUSED_PARAMETER, const char *const tag)
+hunspell_provider_request_dict(EnchantProvider * me _GL_UNUSED, const char *const tag)
 {
 	HunspellChecker * checker = new HunspellChecker();
 
@@ -460,7 +459,7 @@ hunspell_provider_request_dict(EnchantProvider * me _GL_UNUSED_PARAMETER, const 
 }
 
 static void
-hunspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, EnchantDict * dict)
+hunspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED, EnchantDict * dict)
 {
 	HunspellChecker *checker = (HunspellChecker *) dict->user_data;
 	delete checker;
@@ -469,7 +468,7 @@ hunspell_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, Encha
 }
 
 static int
-hunspell_provider_dictionary_exists (struct str_enchant_provider * me _GL_UNUSED_PARAMETER,
+hunspell_provider_dictionary_exists (struct str_enchant_provider * me _GL_UNUSED,
 				     const char *const tag)
 {
 	std::vector <std::string> names;
@@ -492,13 +491,13 @@ hunspell_provider_dispose (EnchantProvider * me)
 }
 
 static const char *
-hunspell_provider_identify (EnchantProvider * me _GL_UNUSED_PARAMETER)
+hunspell_provider_identify (EnchantProvider * me _GL_UNUSED)
 {
 	return "hunspell";
 }
 
 static const char *
-hunspell_provider_describe (EnchantProvider * me _GL_UNUSED_PARAMETER)
+hunspell_provider_describe (EnchantProvider * me _GL_UNUSED)
 {
 	return "Hunspell Provider";
 }

--- a/providers/enchant_nuspell.cpp
+++ b/providers/enchant_nuspell.cpp
@@ -39,7 +39,6 @@
 #include <memory>
 
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 #include <nuspell/dictionary.hxx>
 #include <nuspell/finder.hxx>
@@ -87,7 +86,7 @@ static char** nuspell_dict_suggest(EnchantDict* me, const char* const word,
 static void nuspell_provider_dispose(EnchantProvider* me) { g_free(me); }
 
 static EnchantDict*
-nuspell_provider_request_dict([[maybe_unused]] EnchantProvider* me,
+nuspell_provider_request_dict(_GL_UNUSED EnchantProvider* me,
                               const char* const tag)
 {
 	auto dirs = vector<filesystem::path>();
@@ -111,7 +110,7 @@ nuspell_provider_request_dict([[maybe_unused]] EnchantProvider* me,
 	return dict;
 }
 
-static void nuspell_provider_dispose_dict([[maybe_unused]] EnchantProvider* me,
+static void nuspell_provider_dispose_dict(_GL_UNUSED EnchantProvider* me,
                                           EnchantDict* dict)
 {
 	auto dict_cpp = static_cast<nuspell::Dictionary*>(dict->user_data);
@@ -120,7 +119,7 @@ static void nuspell_provider_dispose_dict([[maybe_unused]] EnchantProvider* me,
 }
 
 static int
-nuspell_provider_dictionary_exists([[maybe_unused]] EnchantProvider* me,
+nuspell_provider_dictionary_exists(_GL_UNUSED EnchantProvider* me,
                                    const char* const tag)
 {
 	auto dirs = vector<filesystem::path>();
@@ -130,19 +129,19 @@ nuspell_provider_dictionary_exists([[maybe_unused]] EnchantProvider* me,
 }
 
 static const char*
-nuspell_provider_identify([[maybe_unused]] EnchantProvider* me)
+nuspell_provider_identify(_GL_UNUSED EnchantProvider* me)
 {
 	return "nuspell";
 }
 
 static const char*
-nuspell_provider_describe([[maybe_unused]] EnchantProvider* me)
+nuspell_provider_describe(_GL_UNUSED EnchantProvider* me)
 {
 	return "Nuspell Provider";
 }
 
 static char**
-nuspell_provider_list_dicts(EnchantProvider* me _GL_UNUSED_PARAMETER,
+nuspell_provider_list_dicts(_GL_UNUSED EnchantProvider* me,
                             size_t* out_n_dicts)
 {
 	auto dicts = nuspell::search_default_dirs_for_dicts();

--- a/providers/enchant_voikko.c
+++ b/providers/enchant_voikko.c
@@ -37,7 +37,6 @@
 #include <string.h>
 
 #include <libvoikko/voikko.h>
-#include "unused-parameter.h"
 
 #include "enchant-provider.h"
 
@@ -81,14 +80,14 @@ voikko_dict_suggest (EnchantDict * me, const char *const word,
 }
 
 static void
-voikko_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, EnchantDict * dict)
+voikko_provider_dispose_dict (EnchantProvider * me _GL_UNUSED, EnchantDict * dict)
 {
 	voikkoTerminate((struct VoikkoHandle *)dict->user_data);
 	free (dict);
 }
 
 static char **
-voikko_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
+voikko_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 			    size_t * out_n_dicts)
 {
 	size_t i;
@@ -112,7 +111,7 @@ voikko_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
 }
 
 static int
-voikko_provider_dictionary_exists (struct str_enchant_provider * me _GL_UNUSED_PARAMETER,
+voikko_provider_dictionary_exists (struct str_enchant_provider * me _GL_UNUSED,
 				   const char *const tag)
 {
 	size_t i;
@@ -160,13 +159,13 @@ voikko_provider_dispose (EnchantProvider * me)
 }
 
 static const char *
-voikko_provider_identify (EnchantProvider * me _GL_UNUSED_PARAMETER)
+voikko_provider_identify (EnchantProvider * me _GL_UNUSED)
 {
 	return "voikko";
 }
 
 static const char *
-voikko_provider_describe (EnchantProvider * me _GL_UNUSED_PARAMETER)
+voikko_provider_describe (EnchantProvider * me _GL_UNUSED)
 {
 	return "Voikko Provider";
 }

--- a/providers/enchant_zemberek.cpp
+++ b/providers/enchant_zemberek.cpp
@@ -34,7 +34,6 @@
 #include <glib.h>
 
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 
 static bool zemberek_service_is_running ()
@@ -169,7 +168,7 @@ zemberek_provider_dispose(EnchantProvider *me)
 }
 
 static EnchantDict*
-zemberek_provider_request_dict(EnchantProvider *me _GL_UNUSED_PARAMETER, const char *tag)
+zemberek_provider_request_dict(EnchantProvider *me _GL_UNUSED, const char *tag)
 {
     if (!((strcmp(tag, "tr") == 0) || (strncmp(tag, "tr_", 3) == 0)))
         return NULL; // only handle turkish
@@ -193,7 +192,7 @@ zemberek_provider_request_dict(EnchantProvider *me _GL_UNUSED_PARAMETER, const c
 }
 
 static void
-zemberek_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, EnchantDict * dict)
+zemberek_provider_dispose_dict (EnchantProvider * me _GL_UNUSED, EnchantDict * dict)
 {
     Zemberek *checker = (Zemberek *) dict->user_data;
     delete checker;
@@ -201,19 +200,19 @@ zemberek_provider_dispose_dict (EnchantProvider * me _GL_UNUSED_PARAMETER, Encha
 }
 
 static const char *
-zemberek_provider_identify (EnchantProvider * me _GL_UNUSED_PARAMETER)
+zemberek_provider_identify (EnchantProvider * me _GL_UNUSED)
 {
         return "zemberek";
 }
 
 static const char *
-zemberek_provider_describe (EnchantProvider * me _GL_UNUSED_PARAMETER)
+zemberek_provider_describe (EnchantProvider * me _GL_UNUSED)
 {
         return "Zemberek Provider";
 }
 
 static char **
-zemberek_provider_list_dicts (EnchantProvider * me _GL_UNUSED_PARAMETER,
+zemberek_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
                               size_t * out_n_dicts)
 {
   if (!zemberek_service_is_running ())

--- a/src/enchant-lsmod.c
+++ b/src/enchant-lsmod.c
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "unused-parameter.h"
 
 #include "enchant.h"
 #include "enchant-provider.h"
@@ -42,18 +41,18 @@
 static void
 describe_dict (const char * const lang_tag,
 	       const char * const provider_name,
-	       const char * const provider_desc _GL_UNUSED_PARAMETER,
-	       const char * const provider_file _GL_UNUSED_PARAMETER,
-	       void * user_data _GL_UNUSED_PARAMETER)
+	       const char * const provider_desc _GL_UNUSED,
+	       const char * const provider_file _GL_UNUSED,
+	       void * user_data _GL_UNUSED)
 {
 	printf ("%s (%s)\n", lang_tag, provider_name);
 }
 
 static void
-describe_word_chars (const char * const lang_tag _GL_UNUSED_PARAMETER,
-		     const char * const provider_name _GL_UNUSED_PARAMETER,
-		     const char * const provider_desc _GL_UNUSED_PARAMETER,
-		     const char * const provider_file _GL_UNUSED_PARAMETER,
+describe_word_chars (const char * const lang_tag _GL_UNUSED,
+		     const char * const provider_name _GL_UNUSED,
+		     const char * const provider_desc _GL_UNUSED,
+		     const char * const provider_file _GL_UNUSED,
 		     void * user_data)
 {
 	EnchantDict *dict = (EnchantDict *)user_data;
@@ -66,8 +65,8 @@ describe_word_chars (const char * const lang_tag _GL_UNUSED_PARAMETER,
 static void
 describe_provider (const char * name,
 		   const char * desc,
-		   const char * file _GL_UNUSED_PARAMETER,
-		   void * user_data _GL_UNUSED_PARAMETER)
+		   const char * file _GL_UNUSED,
+		   void * user_data _GL_UNUSED)
 {
 	printf ("%s (%s)\n", name, desc);
 }

--- a/src/lib.c
+++ b/src/lib.c
@@ -48,7 +48,6 @@
 #include "enchant-provider.h"
 #include "debug.h"
 #include "pwl.h"
-#include "unused-parameter.h"
 #include "relocatable.h"
 #include "configmake.h"
 
@@ -162,7 +161,7 @@ enchant_get_conf_dirs (void)
 /* returns TRUE if tag is valid
  * for requires alphanumeric ASCII or underscore
  */
-static _GL_ATTRIBUTE_PURE int
+static G_GNUC_PURE int
 enchant_is_valid_dictionary_tag(const char * const tag)
 {
 	const char * it;
@@ -1300,7 +1299,7 @@ enchant_broker_dict_exists (EnchantBroker * broker, const char * const tag)
 	return exists;
 }
 
-_GL_ATTRIBUTE_PURE const char *
+G_GNUC_PURE const char *
 enchant_dict_get_extra_word_characters (EnchantDict *dict)
 {
 	g_return_val_if_fail (dict, NULL);
@@ -1308,7 +1307,7 @@ enchant_dict_get_extra_word_characters (EnchantDict *dict)
 	return dict->get_extra_word_characters ? (*dict->get_extra_word_characters) (dict) : "";
 }
 
-_GL_ATTRIBUTE_PURE int
+G_GNUC_PURE int
 enchant_dict_is_word_character (EnchantDict * dict, uint32_t uc_in, size_t n)
 {
 	g_return_val_if_fail (n <= 2, 0);

--- a/src/pwl.c
+++ b/src/pwl.c
@@ -65,7 +65,6 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include "enchant-provider.h"
-#include "unused-parameter.h"
 
 #include "pwl.h"
 
@@ -494,7 +493,7 @@ static int enchant_is_all_caps(const char*const word, size_t len)
 	return hasCap;
 }
 
-static _GL_ATTRIBUTE_PURE int enchant_is_title_case(const char * const word, size_t len)
+static G_GNUC_PURE int enchant_is_title_case(const char * const word, size_t len)
 {
 	g_return_val_if_fail (word && *word, 0);
 
@@ -708,9 +707,9 @@ static void enchant_trie_free(EnchantTrie* trie)
 	g_free(trie);
 }
 
-static void enchant_trie_free_cb(void* key _GL_UNUSED_PARAMETER,
+static void enchant_trie_free_cb(void* key _GL_UNUSED,
 				 void* value,
-				 void* data _GL_UNUSED_PARAMETER)
+				 void* data _GL_UNUSED)
 {
 	enchant_trie_free((EnchantTrie*) value);
 }


### PR DESCRIPTION
- Remove gnulib modules c99, getopt-posix, strdup-posix, ssize_t
- Also remove obsolete gnulib module snippet/unused-parameter, use
  _GL_UNUSED instead of older _GL_UNUSED_PARAMETER, and instead of
  [[maybe_unused]].

Thanks to @dimztimz for providing the patch on which this commit is based.