### PR TITLE
Using "master" instead of "language-tag"

### DIFF
--- a/providers/enchant_aspell.c
+++ b/providers/enchant_aspell.c
@@ -113,7 +113,7 @@ static EnchantDict *
 aspell_provider_request_dict (EnchantProvider * me _GL_UNUSED, const char *const tag)
 {
 	AspellConfig *spell_config = new_aspell_config ();
-	aspell_config_replace (spell_config, "language-tag", tag);
+	aspell_config_replace (spell_config, "master", tag);
 	aspell_config_replace (spell_config, "encoding", "utf-8");
 
 	AspellCanHaveError *spell_error = new_aspell_speller (spell_config);


### PR DESCRIPTION
Followup from #334

Uses the "master" option from [aspell](http://aspell.net/man-html/The-Options.html) so that a dictionary is specified (such as `en-GB` or `en-GB_ize`) instead of a language.

Test with:
```
> echo "categorize authorize randomize wrongg" > /tmp/test
> enchant-2 -l -d en_GB /tmp/test
categorize
authorize
randomize
wrongg

> enchant-2 -l -d en_GB_ize /tmp/test
wrongg
```