### PR TITLE
Conditional changing of dash to underscore in a language tag

### DIFF
--- a/src/lib.c
+++ b/src/lib.c
@@ -169,9 +169,11 @@ enchant_normalize_dictionary_tag (const char * const dict_tag)
 	*strchrnul (new_tag, '.') = '\0';
 
 	/* turn en-GB into en_GB */
-	char * needle;
-	if ((needle = strchr (new_tag, '-')) != NULL)
-		*needle = '_';
+        char * needle_dash;
+        char * needle = strchrnul (new_tag, '_');
+	if (((needle_dash = strchr (new_tag, '-')) != NULL) &&
+            (needle > needle_dash))
+		*needle_dash = '_';
 
 	/* everything before first '_' is converted to lower case */
 	needle = strchrnul (new_tag, '_');


### PR DESCRIPTION
Follow up from #336

Only change the dash to an underscore if it occurs before an underscore (or no underscore exists). This makes the tags compatible with aspell variants. Not both `en-gb-ize` and `en_gb-ize` get normalized as `en_GB-IZE` which works with aspell.