### PR TITLE
Bump version to 2.6.1 and add NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+2.6.1 (September 24, 2023)
+--------------------------
+
+This version tweaks normalization of language tags so that only the part of
+the tag that specifies country and language is altered; any extra that is
+not removed is left alone. This fixes the use case for Aspell dictionaries
+that was fixed in the Aspell backend in 2.6.0. Thanks again to Abdul-Lateef
+Haji-Ali for the report and help with the fix.
+
+
 2.6.0 (September 24, 2023)
 --------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.0])
+AC_INIT([enchant],[2.6.1])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/src/lib.c
+++ b/src/lib.c
@@ -168,18 +168,20 @@ enchant_normalize_dictionary_tag (const char * const dict_tag)
 	/* strip off en_GB.UTF-8 */
 	*strchrnul (new_tag, '.') = '\0';
 
-	/* turn en-GB into en_GB */
-	char * needle;
-	if ((needle = strchr (new_tag, '-')) != NULL)
-		*needle = '_';
-
-	/* everything before first '_' is converted to lower case */
-	needle = strchrnul (new_tag, '_');
-	for (gchar *it = new_tag; it != needle; ++it)
+	/* everything before first '_' or '-' is converted to lower case */
+	gchar *it = new_tag;
+	for (; *it != '\0' && *it != '-' && *it != '_'; ++it)
 		*it = g_ascii_tolower (*it);
-	/* everything after first '_' is converted to upper case */
-	for (gchar *it = needle; *it; ++it)
-		*it = g_ascii_toupper (*it);
+
+	/* turn en-GB into en_GB */
+	if (*it == '-')
+		*it = '_';
+
+	/* first run of alphanumberics after first '_' is converted to upper
+	   case */
+	if (*it != '\0')
+		for (++it; g_ascii_isalnum (*it); ++it)
+			*it = g_ascii_toupper (*it);
 
 	return new_tag;
 }


### PR DESCRIPTION
- Make tag normalization more conservative: normalize only the bit that looks like a language tag
- configure.ac: bump version to 2.6.1 and add NEWS
