### PR TITLE
Document exclude files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+2.6.2 (October 28, 2023)
+------------------------
+
+This version documents exclude files: each personal word list is paired with
+an exclude file that contains words the user considers invalid.
+
+
 2.6.1 (September 24, 2023)
 --------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.1])
+AC_INIT([enchant],[2.6.2])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/src/enchant.5.in
+++ b/src/enchant.5.in
@@ -32,6 +32,13 @@ en_GB:hunspell,nuspell,aspell
 fr:hunspell,nuspell,aspell
 .SH PERSONAL WORD LISTS
 Personal word lists are simple plain text files with one word per line.
+The name of the file starts with the language tag and ends \fI.dic\fR.
+Each personal word list has a corresponding exclude file, ending in
+\fI.exc\fR, which lists words that are found in the dictionary but that the
+user wants to be considered invalid.
+The files are stored in an Enchant configuration directory; see
+.B FILES AND DIRECTORIES
+below.
 Lines starting with a hash sign \(oq#\(cq are ignored.
 .SS SHARING PERSONAL WORD LISTS BETWEEN SPELL-CHECKERS
 It is possible, and usually safe, to share Enchant\(cqs personal word lists

--- a/src/enchant.html
+++ b/src/enchant.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.4 -->
-<!-- CreationDate: Sun Sep 24 15:52:23 2023 -->
+<!-- CreationDate: Sat Oct 28 15:41:14 2023 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -73,7 +73,13 @@ fr:hunspell,nuspell,aspell</p>
 
 <p style="margin-left:11%; margin-top: 1em">Personal word
 lists are simple plain text files with one word per line.
-Lines starting with a hash sign &rsquo;#&rsquo; are
+The name of the file starts with the language tag and ends
+<i>.dic</i>. Each personal word list has a corresponding
+exclude file, ending in <i>.exc</i>, which lists words that
+are found in the dictionary but that the user wants to be
+considered invalid. The files are stored in an Enchant
+configuration directory; see <b>FILES AND DIRECTORIES</b>
+below. Lines starting with a hash sign &rsquo;#&rsquo; are
 ignored.</p>
 
 <p style="margin-left:11%; margin-top: 1em"><b>SHARING


### PR DESCRIPTION
- Document exclude files in enchant(5) (fix #342)
- Bump version to 2.6.2 and add NEWS
