### PR TITLE
Version 2.6.3: fix handling of pkgdatadir in tests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+2.6.3 (December 2, 2023)
+-----------------------
+
+This version fixes a bug in the tests when pkgdatadir is set to a
+non-default value, and clarifies the documentation for setting pkgdatadir.
+
+
 2.6.2 (October 28, 2023)
 ------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.2])
+AC_INIT([enchant],[2.6.3])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/gl/doc/INSTALL.diff
+++ b/gl/doc/INSTALL.diff
@@ -27,7 +27,7 @@
 +versions can be installed in parallel.  The one exception is the data files
 +(under pkgdatadir), as these are compatible between different major
 +versions.  To change e.g. /usr/share/enchant to /usr/share/enchant-2, set
-+pkgdatadir when running make, e.g.:
++pkgdatadir when running any make command (including check & install), e.g.:
 +
 +make pkgdatadir=/usr/share/enchant-2
 +

--- a/tests/EnchantTestFixture.h
+++ b/tests/EnchantTestFixture.h
@@ -38,6 +38,7 @@
 #include <codecvt>
 
 #include "enchant.h"
+#include "enchant-provider.h"
 
 struct EnchantTestFixture
 {
@@ -66,7 +67,9 @@ struct EnchantTestFixture
 
     std::string GetEnchantConfigDir()
     {
-        return AddToPath("share", "enchant");
+        GSList *config_dirs = enchant_get_conf_dirs();
+        const char *pkgdatadir = (char *)g_slist_nth(config_dirs, 0)->data;
+        return std::string(pkgdatadir);
     }
 
     static void DeleteDirAndFiles(const std::string& dir)


### PR DESCRIPTION
- Tests: use actual pkgdatadir, not hardwired value (fix #273)
- INSTALL: clarify that pkgdatadir setting must be given to all make commands
- configure.ac: bump version to 2.6.3 and add NEWS
