### PR TITLE
Make pkgdatadir versioned and release 2.6.4

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,7 +10,7 @@ jobs:
       ASAN_FLAGS: "-fsanitize=address -fsanitize=undefined"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with: { submodules: true }
     - name: Install dependencies
       run: sudo apt-get -y install libglib2.0-dev libaspell-dev hspell libhunspell-dev libvoikko-dev voikko-fi aspell-en libunittest++-dev hunspell-fr groff
@@ -41,7 +41,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with: { submodules: true }
     - name: Install dependencies
       run: |
@@ -84,7 +84,7 @@ jobs:
           mingw-w64-${{matrix.env}}-hunspell-en
           mingw-w64-${{matrix.env}}-nuspell
           mingw-w64-${{matrix.env}}-unittest-cpp
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with: { submodules: true }
     - name: Bootstrap (gnulib and autoreconf)
       run: ./bootstrap

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
+2.6.3 (December 11, 2023)
+-------------------------
+
+This version makes pkgdatadir versioned by default.
+
+
 2.6.3 (December 2, 2023)
------------------------
+------------------------
 
 This version fixes a bug in the tests when pkgdatadir is set to a
 non-default value, and clarifies the documentation for setting pkgdatadir.

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.3])
+AC_INIT([enchant],[2.6.4])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -142,10 +142,8 @@ glib_DEFUN([GLIB_LC_MESSAGES],
 GLIB_LC_MESSAGES
 
 AC_LANG_PUSH([C++])
-dnl FIXME: we need UnitTest++ >= 1.6, but adding the version check breaks
-dnl the Windows build: https://github.com/msys2/MINGW-packages/issues/17297
 PKG_CHECK_EXISTS([UnitTest++],
-    [PKG_CHECK_MODULES(UNITTESTPP, [UnitTest++])])
+    [PKG_CHECK_MODULES(UNITTESTPP, [UnitTest++ >= 1.6])])
 AC_LANG_POP([C++])
 
 

--- a/gl/doc/INSTALL.diff
+++ b/gl/doc/INSTALL.diff
@@ -1,6 +1,6 @@
 --- gnulib/doc/INSTALL	2017-02-23 15:26:15.296354123 +0000
 +++ INSTALL	2017-12-08 15:38:22.819949859 +0000
-@@ -1,3 +1,52 @@
+@@ -1,3 +1,47 @@
 +Building and installing libenchant
 +**********************************
 +
@@ -23,13 +23,8 @@
 +Parallel installation
 +=====================
 +
-+Enchant mostly installs in versioned directories, so that different major
-+versions can be installed in parallel.  The one exception is the data files
-+(under pkgdatadir), as these are compatible between different major
-+versions.  To change e.g. /usr/share/enchant to /usr/share/enchant-2, set
-+pkgdatadir when running any make command (including check & install), e.g.:
-+
-+make pkgdatadir=/usr/share/enchant-2
++Enchant installs in versioned directories, so that different major
++versions can be installed in parallel.
 +
 +
 +Relocation

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = AppleSpell.config
 
 provider_LTLIBRARIES =
 providerdir = $(pkglibdir)-@ENCHANT_MAJOR_VERSION@
+libenchant_datadir = $(pkgdatadir)-@ENCHANT_MAJOR_VERSION@
 
 AM_CPPFLAGS = -I$(top_srcdir) $(ISYSTEM)$(top_builddir)/lib $(ISYSTEM)$(top_srcdir)/lib -I$(top_srcdir)/src $(GLIB_CFLAGS) -D_ENCHANT_BUILD=1
 AM_CFLAGS = $(WARN_CFLAGS)
@@ -57,7 +58,7 @@ enchant_zemberek_la_SOURCES = enchant_zemberek.cpp
 
 if WITH_APPLESPELL
 provider_LTLIBRARIES += enchant_applespell.la
-pkgdata_DATA = AppleSpell.config
+libenchant_data_DATA = AppleSpell.config
 endif
 enchant_applespell_la_LIBTOOLFLAGS = $(AM_LIBTOOLFLAGS) --tag=CXX
 enchant_applespell_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,7 +33,8 @@ endif
 libenchant_includedir = $(pkgincludedir)-@ENCHANT_MAJOR_VERSION@
 libenchant_include_HEADERS = enchant.h enchant-provider.h enchant++.h
 
-pkgdata_DATA = enchant.ordering
+libenchant_datadir = $(pkgdatadir)-@ENCHANT_MAJOR_VERSION@
+libenchant_data_DATA = enchant.ordering
 
 dist_man_MANS = enchant-@ENCHANT_MAJOR_VERSION@.1 enchant-lsmod-@ENCHANT_MAJOR_VERSION@.1 enchant.5
 nodist_doc_DATA = enchant-@ENCHANT_MAJOR_VERSION@.html enchant-lsmod-@ENCHANT_MAJOR_VERSION@.html enchant.html
@@ -60,7 +61,7 @@ bin_PROGRAMS = enchant-@ENCHANT_MAJOR_VERSION@ enchant-lsmod-@ENCHANT_MAJOR_VERS
 enchant_@ENCHANT_MAJOR_VERSION@_SOURCES = enchant.c
 enchant_lsmod_@ENCHANT_MAJOR_VERSION@_SOURCES = enchant-lsmod.c
 
-EXTRA_DIST = $(pkgdata_DATA) enchant.1.in enchant-lsmod.1.in
+EXTRA_DIST = $(libenchant_data_DATA) enchant.1.in enchant-lsmod.1.in
 
 .rc.lo:
 	$(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --tag=RC --mode=compile $(RC) $(RCFLAGS) $< -o $@


### PR DESCRIPTION
- configure.ac: add version check for UnitTest++
- Make pkgdatadir a versioned directory by default
- GitHub: update checkout action to v4
- configure.ac: bump version to 2.6.4 and add NEWS
