### PR TITLE
Release 2.6.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+2.x.y (??? ? ????)
+------------------
+
+Hunspell users should note that, contrary to the NEWS entry for 2.6.5, the
+DICPATH environment variable cannot be used to specify the location of
+hunspell dictionaries to Enchant. That is because it only works with the
+hunspell program (which Enchant does not use), not the hunspell library.
+
+
 2.6.5 (January 7, 2024)
 -----------------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,22 @@
-2.x.y (??? ? ????)
-------------------
+2.6.6 (February 4, 2024)
+------------------------
+
+This version fixes the implementation and documentation of system paths for
+configuration files (enchant.ordering). Since version 2.6.4, the wrong path
+was searched for pkgdatadir: not, for example /usr/share/enchant-2, as
+documented, but the old path /usr/share/enchant. The enchant(5) man page
+referred to “DATADIR” rather than the actual configured path. The sysconfdir
+location, typically /etc, was not documented.
 
 Hunspell users should note that, contrary to the NEWS entry for 2.6.5, the
 DICPATH environment variable cannot be used to specify the location of
 hunspell dictionaries to Enchant. That is because it only works with the
 hunspell program (which Enchant does not use), not the hunspell library.
+
+Additional debug logging has been added for developers trying to diagnose
+problems with configuration files and providers, which can be enabled at
+run-time by setting the environment variable G_MESSAGES_DEBUG to
+‘libenchant’.
 
 
 2.6.5 (January 7, 2024)

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.5])
+AC_INIT([enchant],[2.6.6])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])

--- a/configure.ac
+++ b/configure.ac
@@ -227,7 +227,7 @@ src/libenchant.rc
 src/Makefile
 src/enchant.1
 src/enchant-lsmod.1
-src/enchant.5
+src/enchant.5.in
 providers/Makefile
 tests/Makefile
 ], [],

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 /enchant-[1-9]
 /enchant.[15]
+/enchant.5.in
 /enchant.html
 /enchant-[1-9].1
 /enchant-[1-9].html

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,9 +40,15 @@ dist_man_MANS = enchant-@ENCHANT_MAJOR_VERSION@.1 enchant-lsmod-@ENCHANT_MAJOR_V
 nodist_doc_DATA = enchant-@ENCHANT_MAJOR_VERSION@.html enchant-lsmod-@ENCHANT_MAJOR_VERSION@.html enchant.html
 
 edit = sed \
-	-e 's|DATADIR|$(datadir)|g'
+	-e 's|@PKGDATADIR[@]|$(pkgdatadir)|g' \
+	-e 's|@SYSCONFDIR[@]|$(sysconfdir)|g'
 
 DISTCLEANFILES = $(dist_man_MANS) $(nodist_doc_DATA)
+
+enchant.5: $(builddir)/enchant.5.in Makefile.am $(top_builddir)/config.status
+	rm -f $@ $@.tmp
+	$(edit) $(abs_builddir)/enchant.5.in >$@.tmp
+	mv $@.tmp $@
 
 .1.html:
 	groff -mandoc -Thtml $< > $@

--- a/src/enchant.5.in.in
+++ b/src/enchant.5.in.in
@@ -1,6 +1,6 @@
 \" Enchant configuration man page
 \"
-\" Copyright (C) 2022-2023 Reuben Thomas
+\" Copyright (C) 2022-2024 Reuben Thomas
 \"
 \" This library is distributed in the hope that it will be useful,
 \" but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -97,11 +97,14 @@ Default: \fI~/.config/enchant\fR
 \fICSIDL_LOCAL_APPDATA\\enchant\fR (Windows systems)
 Default: \fIC:\\Documents and Settings\\\fRusername\fI\\Local Settings\\Application Data\\enchant
 .TP
-\fIDATADIR/enchant\fR
+\fI@SYSCONFDIR@/enchant-@ENCHANT_MAJOR_VERSION@\fR
+(Or the equivalent location relative to the enchant library for a relocatable build.)
+.TP
+\fI@PKGDATADIR@-@ENCHANT_MAJOR_VERSION@\fR
 (Or the equivalent location relative to the enchant library for a relocatable build.)
 .PP
 Dictionaries are looked for in a subdirectory with the same name as the
-provider; for example, \fIDATADIR/enchant/hunspell\fR and
+provider; for example, \fI@PKGDATADIR@/hunspell\fR and
 \fI~/.config/enchant/hunspell\fR.
 .PP
 Some providers may also look in a standard system directory for their

--- a/src/enchant.html
+++ b/src/enchant.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.4 -->
-<!-- CreationDate: Sat Oct 28 15:41:14 2023 -->
+<!-- CreationDate: Sun Feb  4 18:13:30 2024 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -175,7 +175,15 @@ set.)</p>
 Settings\</i>username<i>\Local Settings\Application
 Data\enchant</i></p>
 
-<p style="margin-left:11%;"><i>DATADIR/enchant</i></p>
+
+<p style="margin-left:11%;"><i>/home/rrt/.local/etc/enchant-2</i></p>
+
+<p style="margin-left:22%;">(Or the equivalent location
+relative to the enchant library for a relocatable
+build.)</p>
+
+
+<p style="margin-left:11%;"><i>/home/rrt/.local/share/enchant-2</i></p>
 
 <p style="margin-left:22%;">(Or the equivalent location
 relative to the enchant library for a relocatable
@@ -183,7 +191,8 @@ build.)</p>
 
 <p style="margin-left:11%; margin-top: 1em">Dictionaries
 are looked for in a subdirectory with the same name as the
-provider; for example, <i>DATADIR/enchant/hunspell</i> and
+provider; for example,
+<i>/home/rrt/.local/share/enchant/hunspell</i> and
 <i>~/.config/enchant/hunspell</i>.</p>
 
 <p style="margin-left:11%; margin-top: 1em">Some providers

--- a/src/lib.c
+++ b/src/lib.c
@@ -128,13 +128,13 @@ enchant_get_conf_dirs (void)
 	char *pkgconfdir = NULL;
 	char *user_config_dir = NULL;
 
-	if ((pkgdatadir = enchant_relocate (PKGDATADIR)) == NULL)
+	if ((pkgdatadir = enchant_relocate (PKGDATADIR "-" ENCHANT_MAJOR_VERSION)) == NULL)
 		goto error_exit;
 	conf_dirs = g_slist_append (conf_dirs, pkgdatadir);
 
 	if ((sysconfdir = enchant_relocate (SYSCONFDIR)) == NULL)
 		goto error_exit;
-	if ((pkgconfdir = g_build_filename (sysconfdir, "enchant", NULL)) == NULL)
+	if ((pkgconfdir = g_build_filename (sysconfdir, "enchant-" ENCHANT_MAJOR_VERSION, NULL)) == NULL)
 		goto error_exit;
 	conf_dirs = g_slist_append (conf_dirs, pkgconfdir);
 	free (sysconfdir);


### PR DESCRIPTION
- NEWS: add a note for the next version about DICPATH (see #354)
- Add more debug logging, mainly for attempts to read config files
- Fix paths used for reading configuration files
- configure.ac: bump version to 2.6.6
- Add NEWS for 2.6.6
