### PR TITLE
Release 2.6.7 with urgent fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+2.6.7 (February 8, 2024)
+------------------------
+
+This version fixes an error introduced in the previous version that caused the Hunspell provider to fail on startup. Apologies!
+
+
 2.6.6 (February 4, 2024)
 ------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.6])
+AC_INIT([enchant],[2.6.7])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])

--- a/providers/enchant_hunspell.cpp
+++ b/providers/enchant_hunspell.cpp
@@ -295,7 +295,7 @@ hunspell_request_dictionary (const char * tag)
 	s_buildDictionaryDirs (dirs);
 
 	for (size_t i = 0; i < dirs.size(); i++) {
-		GError *err;
+		GError *err = NULL;
 		GDir *dir = g_dir_open (dirs[i].c_str(), 0, &err);
 		g_assert ((dir == NULL && err != NULL) || (dir != NULL && err == NULL));
 		if (err == NULL) {


### PR DESCRIPTION
- Ensure GError is initialized to NULL in hunspell provider (fix #356)
- Bump version to 2.6.7 and add NEWS
