### PR TITLE
Release 2.6.8

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -69,7 +69,6 @@ jobs:
       matrix:
         include:
         - { sys: mingw64, env: x86_64 }
-        - { sys: mingw32, env: i686 }
     steps:
     - uses: msys2/setup-msys2@v2
       with:

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.7])
+AC_INIT([enchant],[2.6.8])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])

--- a/providers/enchant_aspell.c
+++ b/providers/enchant_aspell.c
@@ -156,7 +156,7 @@ aspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 	*out_n_dicts = 0;
 	AspellDictInfoEnumeration * dels = aspell_dict_info_list_elements (dlist);
 
-	/* Note: aspell_dict_info_list_size() always returns zero: https://github.com/GNUAspell/aspell/issues/155 */
+	/* Note: aspell_dict_info_list_size() is unimplemented: https://github.com/GNUAspell/aspell/issues/155 */
 	const AspellDictInfo * entry;
 	while ( (entry = aspell_dict_info_enumeration_next(dels)) != 0)
 		(*out_n_dicts)++;

--- a/src/enchant.5.in.in
+++ b/src/enchant.5.in.in
@@ -107,9 +107,8 @@ Dictionaries are looked for in a subdirectory with the same name as the
 provider; for example, \fI@PKGDATADIR@/hunspell\fR and
 \fI~/.config/enchant/hunspell\fR.
 .PP
-Some providers may also look in a standard system directory for their
-dictionaries; the hunspell provider can be configured to do so at build
-time.
+Some providers may also look in specific system and user directories for their
+dictionaries; see the documentation for each supported spell-checker.
 .SH "SEE ALSO"
 .BR enchant-@ENCHANT_MAJOR_VERSION@ (1),
 .BR enchant-lsmod-@ENCHANT_MAJOR_VERSION@ (1)

--- a/src/enchant.5.in.in
+++ b/src/enchant.5.in.in
@@ -103,12 +103,13 @@ Default: \fIC:\\Documents and Settings\\\fRusername\fI\\Local Settings\\Applicat
 \fI@PKGDATADIR@-@ENCHANT_MAJOR_VERSION@\fR
 (Or the equivalent location relative to the enchant library for a relocatable build.)
 .PP
-Dictionaries are looked for in a subdirectory with the same name as the
-provider; for example, \fI@PKGDATADIR@/hunspell\fR and
-\fI~/.config/enchant/hunspell\fR.
+Dictionaries for some providers are looked for in a subdirectory with the
+same name as the provider, for example, \fI@PKGDATADIR@/hunspell\fR and
+\fI~/.config/enchant/hunspell\fR. Currently this only works for Hunspell.
 .PP
-Some providers may also look in specific system and user directories for their
-dictionaries; see the documentation for each supported spell-checker.
+Providers also look in specific system directories, and in some cases and
+user directories, for their dictionaries; see the documentation for each
+provider.
 .SH "SEE ALSO"
 .BR enchant-@ENCHANT_MAJOR_VERSION@ (1),
 .BR enchant-lsmod-@ENCHANT_MAJOR_VERSION@ (1)

--- a/src/enchant.html
+++ b/src/enchant.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.4 -->
-<!-- CreationDate: Sun Feb  4 18:13:30 2024 -->
+<!-- CreationDate: Fri Mar 22 16:02:04 2024 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -196,9 +196,9 @@ provider; for example,
 <i>~/.config/enchant/hunspell</i>.</p>
 
 <p style="margin-left:11%; margin-top: 1em">Some providers
-may also look in a standard system directory for their
-dictionaries; the hunspell provider can be configured to do
-so at build time.</p>
+may also look in specific system and user directories for
+their dictionaries; see the documentation for each supported
+spell-checker.</p>
 
 <h2>SEE ALSO
 <a name="SEE ALSO"></a>


### PR DESCRIPTION
Mostly, confess to the lack of support for user-supplied dictionaries for most back-ends. See issue #358 for planned work on this.

- **enchant.5: remove outdated information about hunspell provider**
- **GitHub CI: drop Win32 build**
- **Aspell: update note about aspell_dict_info_list_size**
- **'Fess up about lack of Enchant user-directory dictionary support**
- **configure.ac: bump version to 2.6.8**
