### PR TITLE
User dictionaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.6.8])
+AC_INIT([enchant],[2.6.9])
 AC_CONFIG_SRCDIR(src/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])

--- a/providers/enchant_aspell.c
+++ b/providers/enchant_aspell.c
@@ -170,8 +170,7 @@ aspell_provider_list_dicts (EnchantProvider * me _GL_UNUSED,
 
 		for (size_t i = 0; i < *out_n_dicts; i++) {
 			entry = aspell_dict_info_enumeration_next (dels);
-			/* FIXME: should this be entry->code or entry->name ? */
-			out_list[i] = g_strdup (entry->code);
+			out_list[i] = g_strdup (entry->name);
 		}
 
 		delete_aspell_dict_info_enumeration (dels);

--- a/providers/enchant_aspell.c
+++ b/providers/enchant_aspell.c
@@ -1,5 +1,6 @@
 /* enchant
  * Copyright (C) 2003,2004 Dom Lachowicz
+ * Copyright (C) 2017-2024 Reuben Thomas
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/providers/enchant_hunspell.cpp
+++ b/providers/enchant_hunspell.cpp
@@ -1,6 +1,6 @@
 /* enchant
  * Copyright (C) 2003-2004 Joan Moratinos <jmo@softcatala.org>, Dom Lachowicz
- * Copyright (C) 2016-2023 Reuben Thomas <rrt@sc3d.org>
+ * Copyright (C) 2016-2023 Reuben Thomas
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/enchant-provider.h
+++ b/src/enchant-provider.h
@@ -1,6 +1,6 @@
 /* enchant
  * Copyright (C) 2003 Dom Lachowicz
- * Copyright (C) 2017-2021 Reuben Thomas
+ * Copyright (C) 2017-2024 Reuben Thomas
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -60,23 +60,33 @@ char *enchant_get_user_language(void);
  * glib's g_get_user_config_dir() is called to get the user's configuration
  * directory, and the sub-directory "enchant" is appended.
  *
- * The returned string must be free'd.
+ * The returned string must be g_free'd.
  */
 char *enchant_get_user_config_dir (void);
 
 /**
-  * enchant_get_conf_dirs
-  *
-  * Returns a list (GSList *) of configuration directories, in the order in
-  * which they are used, or NULL on error.
-  *
-  * The following directories are in the list:
-  *
-  *  + Enchant's internal configuration directory (pkgdatadir)
-  *  + The system configuration directory (sysconfdir/enchant)
-  *  + The user configuration directory, as returned by
-  *     enchant_get_user_config_dir(), if it exists.
-  */
+ * enchant_get_user_dict_dir
+ *
+ * Returns the user dictionary directory for the given provider, or NULL on
+ * error, or if none exists.
+ *
+ * The return value must be g_free'd.
+ */
+char *enchant_get_user_dict_dir (EnchantProvider * provider);
+
+/**
+ * enchant_get_conf_dirs
+ *
+ * Returns a list (GSList *) of configuration directories, in the order in
+ * which they are used, or NULL on error.
+ *
+ * The following directories are in the list:
+ *
+ *  + Enchant's internal configuration directory (pkgdatadir)
+ *  + The system configuration directory (sysconfdir/enchant)
+ *  + The user configuration directory, as returned by
+ *     enchant_get_user_config_dir(), if it exists.
+ */
 GSList *enchant_get_conf_dirs (void);
 
 /**

--- a/src/enchant.5.in.in
+++ b/src/enchant.5.in.in
@@ -86,7 +86,7 @@ output messages useful for debugging. Setting \fIG_MESSAGES_DEBUG\fR to
 \fIlibenchant\fR will cause Enchant to output debugging messages to standard
 error. See the GLib documentation for more details.
 .SH FILES AND DIRECTORIES
-Enchant looks in the following places for files, in decreasing order of precedence:
+Enchant looks in the following places for user files, in decreasing order of precedence:
 .TP
 \fIENCHANT_CONFIG_DIR\fR
 (If the environment variable is set.)
@@ -96,20 +96,22 @@ Default: \fI~/.config/enchant\fR
 .TP
 \fICSIDL_LOCAL_APPDATA\\enchant\fR (Windows systems)
 Default: \fIC:\\Documents and Settings\\\fRusername\fI\\Local Settings\\Application Data\\enchant
+.PP
+Dictionaries for some providers are looked for in a subdirectory with the
+same name as the provider, for example \fI~/.config/enchant/hunspell\fR.
+Currently this works for Hspell, Hunspell, Nuspell and Voikko.
+.PP
+Providers also look in specific system directories, and in some cases and
+user directories, for their dictionaries; see the documentation for each
+provider.
+.PP
+In addition, Enchant looks in the following systems directories for ordering files:
 .TP
 \fI@SYSCONFDIR@/enchant-@ENCHANT_MAJOR_VERSION@\fR
 (Or the equivalent location relative to the enchant library for a relocatable build.)
 .TP
 \fI@PKGDATADIR@-@ENCHANT_MAJOR_VERSION@\fR
 (Or the equivalent location relative to the enchant library for a relocatable build.)
-.PP
-Dictionaries for some providers are looked for in a subdirectory with the
-same name as the provider, for example, \fI@PKGDATADIR@/hunspell\fR and
-\fI~/.config/enchant/hunspell\fR. Currently this only works for Hunspell.
-.PP
-Providers also look in specific system directories, and in some cases and
-user directories, for their dictionaries; see the documentation for each
-provider.
 .SH "SEE ALSO"
 .BR enchant-@ENCHANT_MAJOR_VERSION@ (1),
 .BR enchant-lsmod-@ENCHANT_MAJOR_VERSION@ (1)

--- a/src/enchant.html
+++ b/src/enchant.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.4 -->
-<!-- CreationDate: Fri Mar 22 16:02:04 2024 -->
+<!-- CreationDate: Thu Mar 28 16:14:31 2024 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -154,8 +154,8 @@ the GLib documentation for more details.</p>
 
 
 <p style="margin-left:11%; margin-top: 1em">Enchant looks
-in the following places for files, in decreasing order of
-precedence: <i><br>
+in the following places for user files, in decreasing order
+of precedence: <i><br>
 ENCHANT_CONFIG_DIR</i></p>
 
 <p style="margin-left:22%;">(If the environment variable is
@@ -175,8 +175,25 @@ set.)</p>
 Settings\</i>username<i>\Local Settings\Application
 Data\enchant</i></p>
 
+<p style="margin-left:11%; margin-top: 1em">Dictionaries
+for some providers are looked for in a subdirectory with the
+same name as the provider, for example
+<i>~/.config/enchant/hunspell</i>. Currently this works for
+Aspell, Hunspell, Nuspell and Voikko. Note that for Aspell,
+the user&rsquo;s <i>local-data-dir</i> preference will be
+overridden by Enchant, so that dictionaries installed in
+that location will be ignored in favour of dictionaries in
+the user&rsquo;s Enchant settings directory.</p>
 
-<p style="margin-left:11%;"><i>/home/rrt/.local/etc/enchant-2</i></p>
+<p style="margin-left:11%; margin-top: 1em">Providers also
+look in specific system directories, and in some cases and
+user directories, for their dictionaries; see the
+documentation for each provider.</p>
+
+<p style="margin-left:11%; margin-top: 1em">In addition,
+Enchant looks in the following systems directories for
+ordering files: <i><br>
+/home/rrt/.local/etc/enchant-2</i></p>
 
 <p style="margin-left:22%;">(Or the equivalent location
 relative to the enchant library for a relocatable
@@ -188,17 +205,6 @@ build.)</p>
 <p style="margin-left:22%;">(Or the equivalent location
 relative to the enchant library for a relocatable
 build.)</p>
-
-<p style="margin-left:11%; margin-top: 1em">Dictionaries
-are looked for in a subdirectory with the same name as the
-provider; for example,
-<i>/home/rrt/.local/share/enchant/hunspell</i> and
-<i>~/.config/enchant/hunspell</i>.</p>
-
-<p style="margin-left:11%; margin-top: 1em">Some providers
-may also look in specific system and user directories for
-their dictionaries; see the documentation for each supported
-spell-checker.</p>
 
 <h2>SEE ALSO
 <a name="SEE ALSO"></a>

--- a/src/lib.c
+++ b/src/lib.c
@@ -119,6 +119,15 @@ enchant_get_user_config_dir (void)
 	return g_build_filename (g_get_user_config_dir (), "enchant", NULL);
 }
 
+_GL_ATTRIBUTE_MALLOC char *
+enchant_get_user_dict_dir (EnchantProvider *provider)
+{
+	char *config_dir = enchant_get_user_config_dir ();
+	gchar *dir = g_build_filename (config_dir, provider->identify(provider), NULL);
+	g_free (config_dir);
+	return dir;
+}
+
 GSList *
 enchant_get_conf_dirs (void)
 {
@@ -150,7 +159,7 @@ enchant_get_conf_dirs (void)
 	free (pkgdatadir);
 	free (sysconfdir);
 	g_free (pkgconfdir);
-	free (user_config_dir);
+	g_free (user_config_dir);
 	return NULL;
 }
 


### PR DESCRIPTION
- **Use Aspell’s dictionary ‘name’ not ‘code’**
- **Add my copyright to Aspell provider, use my email address more consistently**
- **Implement user dictionary support for Hspell, Nuspell, Voikko**
- **configure.ac: bump version to 2.6.9**
