### PR TITLE
Fix Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+doxygen/html/*.html linguist-documentation


### PR DESCRIPTION
This PR simply creates a `.gitattributes` to mark doxygen output as documentation for Linguist. For further information about the special attributes that Linguist recognizes, see: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
