### PR TITLE
Rebuild release with valac 0.56.17

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+2.7.3 (April 27, 2024)
+----------------------
+
+This release is made with Vala 0.56.17 (previous versions were made with
+0.56.0). This works around a bug in `valac` that generates code which causes
+an error in GCC >=14 and Clang >= 16.
+
+
 2.7.2 (April 27, 2024)
 ----------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.71])
-AC_INIT([enchant],[2.7.2])
+AC_INIT([enchant],[2.7.3])
 AC_CONFIG_SRCDIR(lib/enchant.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-AM_VALAFLAGS = --debug --no-color --vapidir=. --pkg config --pkg internal --pkg posix --pkg gnu --pkg gio-2.0 --pkg gmodule-2.0
+AM_VALAFLAGS = --debug --no-color --vapidir=$(srcdir) --pkg config --pkg internal --pkg posix --pkg gnu --pkg gio-2.0 --pkg gmodule-2.0
 AM_CPPFLAGS = --include config.h -I$(top_srcdir) $(ISYSTEM)$(top_builddir)/libgnu $(ISYSTEM)$(top_srcdir)/libgnu $(GLIB_CFLAGS) $(WARN_CFLAGS) -DG_LOG_DOMAIN='"libenchant"'
 
 # FIXME: Require Vala 0.58 when released, and remove copy of gnu.vapi

--- a/lib/api.vala
+++ b/lib/api.vala
@@ -40,8 +40,6 @@ public unowned string enchant_get_version() {
 
 public string enchant_get_user_language() {
 	// The returned list always contains "C".
-	string[] languages = Intl.get_language_names();
-	assert(languages != null);
-
+	unowned string[] languages = Intl.get_language_names();
 	return languages[0] == "C" ? "en" : languages[0];
 }


### PR DESCRIPTION
This release is made with Vala 0.56.17 (previous versions were made with
0.56.0). This works around a bug in `valac` that generates code which causes
an error in GCC >=14 and Clang >= 16.

Otherwise, only slight clean-up has been performed since 2.7.2.