### PR TITLE
hspell: Use g_warning instead of g_return_val_if_fail

### DIFF
--- a/providers/enchant_hspell.c
+++ b/providers/enchant_hspell.c
@@ -86,8 +86,13 @@ static int
 hspell_dict_check (EnchantDict * me, const char *const word, size_t len)
 {
 	struct dict_radix *hspell_dict = (struct dict_radix *)me->user_data;
-	char *iso_word = hspell_convert_to_iso8859_8 (me, word, len);
-	g_return_val_if_fail (iso_word, -1);
+	char *iso_word = NULL;
+
+	iso_word = hspell_convert_to_iso8859_8 (me, word, len);
+	if (!iso_word) {
+		g_warning ("%s: Can't convert word to iso8859_8", __FUNCTION__);
+		return -1;
+	}
 
 	/* check */
 	int preflen;
@@ -107,8 +112,13 @@ hspell_dict_suggest (EnchantDict * me, const char *const word,
 		     size_t len, size_t * out_n_suggs)
 {
 	struct dict_radix *hspell_dict = (struct dict_radix *)me->user_data;
-	char *iso_word = hspell_convert_to_iso8859_8 (me, word, len);
-	g_return_val_if_fail (iso_word, NULL);
+	char *iso_word = NULL;
+
+	iso_word = hspell_convert_to_iso8859_8 (me, word, len);
+	if (!iso_word) {
+		g_warning ("%s: Can't convert word to iso8859_8", __FUNCTION__);
+		return NULL;
+	}
 
 	/* get suggestions */
 	struct corlist cl;


### PR DESCRIPTION
Epiphsny set (commit #70f8362e) critical warnings as fatal, so when hspell_convert_to_iso8859_8 failed, epiphany crash instead of just log a warning.

Fix this by using g_warning instead of g_return_if_fail so epiphany will not crash for this.

Fix #394