### PR TITLE
hspell: Correct usage of g_return_val_if_fail and g_warning

### DIFF
--- a/providers/enchant_hspell.c
+++ b/providers/enchant_hspell.c
@@ -87,7 +87,10 @@ hspell_dict_check (EnchantDict * me, const char *const word, size_t len)
 {
 	struct dict_radix *hspell_dict = (struct dict_radix *)me->user_data;
 	char *iso_word = hspell_convert_to_iso8859_8 (me, word, len);
-	g_return_val_if_fail (iso_word, -1);
+	if (iso_word == NULL) {
+		g_warning ("%s: Can't convert word to iso8859-8", __FUNCTION__);
+		return -1;
+	}
 
 	/* check */
 	int preflen;
@@ -108,7 +111,10 @@ hspell_dict_suggest (EnchantDict * me, const char *const word,
 {
 	struct dict_radix *hspell_dict = (struct dict_radix *)me->user_data;
 	char *iso_word = hspell_convert_to_iso8859_8 (me, word, len);
-	g_return_val_if_fail (iso_word, NULL);
+	if (iso_word == NULL) {
+		g_warning ("%s: Can't convert word to iso8859-8", __FUNCTION__);
+		return NULL;
+	}
 
 	/* get suggestions */
 	struct corlist cl;


### PR DESCRIPTION
Epiphany's commit #70f8362e treats critical warnings as fatal, causing epiphany to crash when hspell_convert_to_iso8859_8 fails instead of just logging a warning.

The g_return_val_if_fail macro is intended to validate parameters passed to a function, meaning it should only be used to indicate programmer errors.

This commit adds g_return_val_if_fail to check only the function’s parameters, and replaces g_return_if_fail with g_warning for checking the result of hspell_convert_to_iso8859_8.

Fix #394