### PR TITLE
Fix reference to AbiWord.

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ Enchant comes with a couple of command-line utilities:
 <h2>Programs using Enchant</h2>
 
 <p>Enchant is used by <a href="https://www.gnu.org/software/emacs/">GNU
-Emacs</a> (as of version 27.1), <a href="http://www.nl.abisource.com/">rrthomas</a>,
+Emacs</a> (as of version 27.1), <a href="https://github.com/AbiWord/abiword/">AbiWord</a>,
 <a href="https://www.lyx.org">LyX</a>, and,
 via <a href="https://wiki.gnome.org/Projects/gspell">gspell</a>
 and <a href="http://gtkspell.sourceforge.net">GtkSpell</a>, a number of Gtk


### PR DESCRIPTION
This fixes an oversight in fb7906f643c094eb516843e71f379f6cfd2f9ac5 while searching and replacing `abiword` with `rrthomas`. Since the [website](http://www.nl.abisource.com/) is down, and has been for awhile, I've decided to point to their GitHub mirror instead.