### PR TITLE
Fix main.test testcase failure in s390x

### DIFF
--- a/lib/composite.vala
+++ b/lib/composite.vala
@@ -51,6 +51,7 @@ int composite_dict_check(EnchantDict? self, string word_buf, real_size_t len) {
 	return err;
 }
 
+[CCode (array_length_pos = 4, array_length_type = "size_t")]
 string[]? composite_dict_suggest(EnchantDict me, string word, real_size_t len) {
 	var cdict = (EnchantCompositeDict)(me.user_data);
 	var error = true;


### PR DESCRIPTION
Fixes issue #406

Without explicitly specifying `size_t*`, the `result_length1` argument inside the function `composite_dict_suggest` was having a type of `gint*` inside `composite.c`. This, in big endian machines, will set the value in the upper 32 bits which is causing the issue.