### PR TITLE
Update broker.vala

### DIFF
--- a/lib/broker.vala
+++ b/lib/broker.vala
@@ -138,7 +138,7 @@ public class EnchantBroker {
 			if (dir_entry[0] != '.') { /* Skip hidden files */
 				string filename = Path.build_filename(dir_name, dir_entry);
 				try {
-					module = new Module(filename, 0);
+					module = Module.open(filename, ModuleFlags.BIND_LAZY);
 					void *init_func;
 					if (module.symbol("init_enchant_provider", out init_func)
 						&& init_func != null) {


### PR DESCRIPTION
Hello!
I find a bug in broker module.

GLib.Module is a wrapper around the system API for dynamically loading libraries (plugins). On Linux, this corresponds to functions like dlopen() and dlsym(). By nature, this operation is not about creating a new "object" in the classic OOP sense, but rather opening an existing library file and obtaining a handle to it.

Within the GLib/GObject ecosystem (which Vala is closely tied to), such "non-standard" objects often do not have public constructors (new). Instead, they provide static factory methods, like Module.open().

The code new Module(filename, 0); implied that the GLib.Module class had a public constructor accepting a string and a number. However, no such constructor exists in the public Vala/GLib API.

You can think of it this way:

new Module(...) is a command: "Create a brand new, unique module for me" (which is meaningless, as a module is a file on disk).

Module.open(...) is a command: "Find and open the existing library file at this path for me".

Please apply my fix for broker.vala:

before:
with module = new Module(filename, 0);

after:
on module = Module.open(filename, ModuleFlags.BIND_LAZY);