### PR TITLE
feat: native windows provider

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -80,6 +80,7 @@ jobs:
           patch git groff
           mingw-w64-${{matrix.env}}-autotools
           mingw-w64-${{matrix.env}}-pkg-config
+          mingw-w64-${{matrix.env}}-crt
           mingw-w64-${{matrix.env}}-gcc
           mingw-w64-${{matrix.env}}-vala
           mingw-w64-${{matrix.env}}-glib2
@@ -94,7 +95,9 @@ jobs:
     - name: Bootstrap (gnulib and autoreconf)
       run: ./bootstrap
     - name: configure
-      run: ./configure --enable-relocatable
+      # set lt_cv_deplibs_check_method to pass_all to work around linker error regarding -luuid
+      # similar issue as https://github.com/msys2/MINGW-packages/issues/16836
+      run: lt_cv_deplibs_check_method='pass_all' ./configure --enable-relocatable
     - name: make
       run: make --jobs=`nproc`
     - name: make check

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Enchant works with the following spell-checkers:
 * Hspell
 * Voikko
 * Apple Spell (macOS only)
+* WinSpell (Windows only)
 * Zemberek
 
 Enchant is written in Vala, C and C++, and its only external dependency is

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -40,13 +40,14 @@ gnulib_git_submodules=gl-mod/bootstrap
 
 # Additional gnulib-tool options to use.
 gnulib_tool_options='
-        --lgpl=2
+        --lgpl
         --makefile-name=Makefile.gnulib
 '
 
 # gnulib modules used by this package.
 gnulib_modules='
         bootstrap
+        bcp47
         configmake
         flock
         getopt-posix

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (Enchant) version 2024-05-05
+# bootstrap.conf (Enchant) version 2026-07-04
 
 # This file is part of Enchant.
 #
@@ -47,6 +47,7 @@ gnulib_tool_options='
 # gnulib modules used by this package.
 gnulib_modules='
         bootstrap
+        bcp47
         configmake
         flock
         getopt-posix

--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,20 @@ ENCHANT_CHECK_PKG_CONFIG_PROVIDER([nuspell], [NUSPELL], [nuspell >= 5.1.0])
 ENCHANT_CHECK_LIB_PROVIDER([aspell], [ASPELL], [get_aspell_dict_info_list],,, [ASPELL_H])
 ENCHANT_CHECK_LIB_PROVIDER([hspell], [HSPELL], [hspell_get_dictionary_path],, [-lz], [HSPELL_H])
 ENCHANT_CHECK_PKG_CONFIG_PROVIDER([voikko], [VOIKKO], [libvoikko])
+
+dnl Windows 8 Spell Checking API provider
+if test "$native_win32" = "yes"; then
+  AC_LANG_PUSH([C++])
+  AC_CHECK_HEADERS([spellcheck.h], [HAVE_SPELLCHECK_H=yes])
+  ENCHANT_CHECK_LIB_PROVIDER([win8], [WIN8], [NOLIB],, [-lole32 -loleaut32 -luuid], [SPELLCHECK_H])
+  AC_LANG_POP([C++])
+fi
+dnl Must call AM_CONDITIONAL outside conditional
+AM_CONDITIONAL(WITH_WIN8, test "$with_win8" = yes)
+dnl Add Windows target to CFLAGS.
+AS_IF([test "$with_win8" = yes],
+  [WIN8_CFLAGS="-D_WIN32_WINNT=_WIN32_WINNT_WIN8 -DNTDDI_VERSION=NTDDI_WIN8" AC_SUBST([WIN8_CFLAGS])])
+
 dnl FIXME: The test below assumes GCC(-compatible) ObjC++ compiler, but
 dnl OBJCXX is set even if no compiler is found.
 if test "$ac_cv_objcxx_compiler_gnu" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -217,18 +217,18 @@ ENCHANT_CHECK_LIB_PROVIDER([aspell], [ASPELL], [get_aspell_dict_info_list],,, [A
 ENCHANT_CHECK_LIB_PROVIDER([hspell], [HSPELL], [hspell_get_dictionary_path],, [-lz], [HSPELL_H])
 ENCHANT_CHECK_PKG_CONFIG_PROVIDER([voikko], [VOIKKO], [libvoikko])
 
-dnl Windows 8 Spell Checking API provider
+dnl WinSpell provider
 if test "$native_win32" = "yes"; then
   AC_LANG_PUSH([C++])
   AC_CHECK_HEADERS([spellcheck.h], [HAVE_SPELLCHECK_H=yes])
-  ENCHANT_CHECK_LIB_PROVIDER([win8], [WIN8], [NOLIB],, [-lole32 -loleaut32 -luuid], [SPELLCHECK_H])
+  ENCHANT_CHECK_LIB_PROVIDER([winspell], [WINSPELL], [NOLIB],, [-lole32 -loleaut32 -luuid], [SPELLCHECK_H])
   AC_LANG_POP([C++])
 fi
 dnl Must call AM_CONDITIONAL outside conditional
-AM_CONDITIONAL(WITH_WIN8, test "$with_win8" = yes)
-dnl Add Windows target to CFLAGS.
-AS_IF([test "$with_win8" = yes],
-  [WIN8_CFLAGS="-D_WIN32_WINNT=_WIN32_WINNT_WIN8 -DNTDDI_VERSION=NTDDI_WIN8" AC_SUBST([WIN8_CFLAGS])])
+AM_CONDITIONAL(WITH_WINSPELL, test "$with_winspell" = yes)
+dnl Set target to Windows 8 using CFLAGS.
+WINSPELL_CFLAGS="-D_WIN32_WINNT=_WIN32_WINNT_WIN8 -DNTDDI_VERSION=NTDDI_WIN8"
+AC_SUBST([WINSPELL_CFLAGS])
 
 dnl FIXME: The test below assumes GCC(-compatible) ObjC++ compiler, but
 dnl OBJCXX is set even if no compiler is found.

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,19 @@ ENCHANT_CHECK_PKG_CONFIG_PROVIDER([nuspell], [NUSPELL], [nuspell >= 5.1.0])
 ENCHANT_CHECK_LIB_PROVIDER([aspell], [ASPELL], [get_aspell_dict_info_list],,, [ASPELL_H])
 ENCHANT_CHECK_LIB_PROVIDER([hspell], [HSPELL], [hspell_get_dictionary_path],, [-lz], [HSPELL_H])
 ENCHANT_CHECK_PKG_CONFIG_PROVIDER([voikko], [VOIKKO], [libvoikko])
+
+dnl WinSpell provider
+if test "$native_win32" = "yes"; then
+  AC_LANG_PUSH([C++])
+  AC_CHECK_HEADERS([spellcheck.h], [HAVE_SPELLCHECK_H=yes])
+  ENCHANT_CHECK_LIB_PROVIDER([winspell], [WINSPELL], [NOLIB],, [-lole32 -loleaut32 -luuid], [SPELLCHECK_H])
+  AC_LANG_POP([C++])
+fi
+AM_CONDITIONAL(WITH_WINSPELL, test "$with_winspell" = yes)
+dnl Set target to Windows 8
+WINSPELL_CFLAGS="-D_WIN32_WINNT=_WIN32_WINNT_WIN8 -DNTDDI_VERSION=NTDDI_WIN8"
+AC_SUBST([WINSPELL_CFLAGS])
+
 dnl FIXME: The test below assumes GCC(-compatible) ObjC++ compiler, but
 dnl OBJCXX is set even if no compiler is found.
 if test "$ac_cv_objcxx_compiler_gnu" = "yes"; then

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -49,6 +49,13 @@ endif
 enchant_voikko_la_CFLAGS = $(AM_CFLAGS) $(VOIKKO_CFLAGS)
 enchant_voikko_la_LIBADD = $(VOIKKO_LIBS)
 
+if WITH_WIN8
+provider_LTLIBRARIES += enchant_win8.la
+endif
+enchant_win8_la_CXXFLAGS = $(AM_CXXFLAGS) $(WIN8_CFLAGS)
+enchant_win8_la_LIBADD = $(WIN8_LIBS)
+enchant_win8_la_SOURCES = enchant_win8.cpp
+
 if WITH_ZEMBEREK
 provider_LTLIBRARIES += enchant_zemberek.la
 endif

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -49,12 +49,12 @@ endif
 enchant_voikko_la_CFLAGS = $(AM_CFLAGS) $(VOIKKO_CFLAGS)
 enchant_voikko_la_LIBADD = $(VOIKKO_LIBS)
 
-if WITH_WIN8
-provider_LTLIBRARIES += enchant_win8.la
+if WITH_WINSPELL
+provider_LTLIBRARIES += enchant_winspell.la
 endif
-enchant_win8_la_CXXFLAGS = $(AM_CXXFLAGS) $(WIN8_CFLAGS)
-enchant_win8_la_LIBADD = $(WIN8_LIBS)
-enchant_win8_la_SOURCES = enchant_win8.cpp
+enchant_winspell_la_CXXFLAGS = $(AM_CXXFLAGS) $(WINSPELL_CFLAGS)
+enchant_winspell_la_LIBADD = $(WINSPELL_LIBS)
+enchant_winspell_la_SOURCES = enchant_winspell.cpp
 
 if WITH_ZEMBEREK
 provider_LTLIBRARIES += enchant_zemberek.la

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -51,6 +51,13 @@ endif
 enchant_voikko_la_CFLAGS = $(AM_CFLAGS) $(VOIKKO_CFLAGS)
 enchant_voikko_la_LIBADD = $(VOIKKO_LIBS)
 
+if WITH_WINSPELL
+provider_LTLIBRARIES += enchant_winspell.la
+endif
+enchant_winspell_la_CXXFLAGS = $(AM_CXXFLAGS) $(WINSPELL_CFLAGS)
+enchant_winspell_la_LIBADD = $(WINSPELL_LIBS)
+enchant_winspell_la_SOURCES = enchant_winspell.cpp
+
 if WITH_ZEMBEREK
 provider_LTLIBRARIES += enchant_zemberek.la
 endif

--- a/providers/enchant_win8.cpp
+++ b/providers/enchant_win8.cpp
@@ -1,4 +1,7 @@
-/* MIT License
+/* Note: This file links against LGPLv3+ gnulib modules (bcp47).
+ * The combined work is thus distributed under LGPLv3+.
+ *
+ * MIT License
  *
  * Copyright (c) 2026 Moritz Mechelk
  *
@@ -12,8 +15,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -26,6 +29,7 @@
 
 #include "config.h"
 
+#include <bcp47.h>
 #include <glib.h>
 #include <spellcheck.h>
 
@@ -33,56 +37,69 @@
 
 /* --------- Utils ----------*/
 
+// convert bcp47 tags (e.g. "en-US") to xpg tags (e.g. "en_US")
 static char*
-utf16_to_utf8(const wchar_t* const str, gboolean from_bcp47)
+tag_bcp47_to_xpg(const char* const bcp47)
 {
-    char* utf8 = g_utf16_to_utf8((gunichar2*)str, -1, nullptr, nullptr, nullptr);
-    if (utf8 && from_bcp47) {
-        char* p = utf8;
-        // bcp47 tags use syntax "en-US" while the myspell versions are "en_US"
-        while (*p) {
-            if (*p == '-')
-                *p = '_';
-            p++;
-        }
-    }
-    return utf8;
+	if (!bcp47) {
+		return nullptr;
+	}
+
+	char* xpg = g_new0(char, BCP47_MAX);
+	if (!xpg) {
+		return nullptr;
+	}
+
+	bcp47_to_xpg(xpg, bcp47, nullptr);
+	return xpg;
 }
 
-static wchar_t*
-utf8_to_utf16(const char* const str, gssize len, gboolean to_bcp47)
+// convert xpg tags (e.g. "en_US") to bcp47 tags (e.g. "en-US")
+static char*
+tag_xpg_to_bcp47(const char* const xpg)
 {
-    wchar_t* utf16 = (wchar_t*)g_utf8_to_utf16(str, (glong)len, nullptr, nullptr, nullptr);
-    if (utf16 && to_bcp47) {
-        wchar_t* p = utf16;
-        // bcp47 tags use syntax "en-US" while the myspell versions are "en_US"
-        while (*p) {
-            if (*p == L'_')
-                *p = L'-';
-            p++;
-        }
-    }
-    return utf16;
+	if (!xpg) {
+		return nullptr;
+	}
+
+	char* bcp47 = g_new0(char, BCP47_MAX);
+	if (!bcp47) {
+		return nullptr;
+	}
+
+	xpg_to_bcp47(bcp47, xpg);
+	return bcp47;
 }
 
 static char**
-enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean from_bcp47)
+enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean tags_from_bcp47)
 {
-    GArray* array = g_array_new(TRUE, FALSE, sizeof(char*));
-    LPOLESTR wstr = nullptr;
+	GArray* array = g_array_new(TRUE, FALSE, sizeof(char*));
 
-    while (SUCCEEDED(strings->Next(1, &wstr, nullptr)) && wstr) {
-        char* str = utf16_to_utf8(wstr, from_bcp47);
-        if (str) {
-            g_array_append_val(array, str);
-        }
-        CoTaskMemFree(wstr);
-    }
-    strings->Release();
+	LPOLESTR w_str;
+	while (SUCCEEDED(strings->Next(1, &w_str, nullptr)) && w_str) {
+		char* str = g_utf16_to_utf8((gunichar2*)w_str, -1, nullptr, nullptr, nullptr);
 
-    *out_len = array->len;
-    char** result = (char**)g_array_free(array, FALSE);
-    return result;
+		if (str) {
+			if (tags_from_bcp47) {
+				char* xpg_tag = tag_bcp47_to_xpg(str);
+				g_free(str);
+
+				if (xpg_tag) {
+					g_array_append_val(array, xpg_tag);
+				}
+			} else {
+				g_array_append_val(array, str);
+			}
+		}
+
+		CoTaskMemFree(w_str);
+	}
+
+	strings->Release();
+
+	*out_len = array->len;
+	return (char**)g_array_free(array, FALSE);
 }
 
 /* ---------- Dict ------------ */
@@ -90,161 +107,178 @@ enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean from_bcp
 static void
 win8_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size_t len)
 {
-    auto checker = static_cast<ISpellChecker*>(dict->user_data);
-    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
 
-    if (wword) {
-        checker->Add(wword);
-        g_free(wword);
-    }
+	if (w_word) {
+		checker->Add(w_word);
+		g_free(w_word);
+	}
 }
 
 static void
 win8_dict_remove_from_session(EnchantProviderDict* dict, const char* const word, size_t len)
 {
-    auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
 
-    // try to use ISpellChecker2::Remove if available (Windows 10+)
-    ISpellChecker2* checker2 = nullptr;
-    if (SUCCEEDED(checker->QueryInterface(__uuidof(ISpellChecker2), (void**)&checker2))) {
-        wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+	// try to use ISpellChecker2::Remove if available (Windows 10+)
+	ISpellChecker2* checker2;
+	if (SUCCEEDED(checker->QueryInterface(__uuidof(ISpellChecker2), (void**)&checker2))) {
+		LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
 
-        if (wword) {
-            checker2->Remove(wword);
-            g_free(wword);
-        }
+		if (w_word) {
+			checker2->Remove(w_word);
+			g_free(w_word);
+		}
 
-        checker2->Release();
-    }
+		checker2->Release();
+	}
 }
 
 static int
 win8_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
 {
-    auto checker = static_cast<ISpellChecker*>(dict->user_data);
-    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
-    IEnumSpellingError* errors;
-    ISpellingError* error = nullptr;
-    HRESULT hr;
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
 
-    if (!wword) {
-        return -1; // conversion error
-    }
+	if (!w_word) {
+		return -1; // conversion error
+	}
 
-    hr = checker->Check(wword, &errors);
-    g_free(wword);
+	IEnumSpellingError* errors;
+	HRESULT hr = checker->Check(w_word, &errors);
+	g_free(w_word);
 
-    if (FAILED(hr)) {
-        return -1; // error
-    }
+	if (FAILED(hr)) {
+		return -1; // error
+	}
 
-    if (errors->Next(&error) == S_OK) {
-        error->Release();
-        errors->Release();
-        return 1; // spelling issue
-    }
-    
-    errors->Release();
-    return 0; // correct
+	ISpellingError* error;
+	if (errors->Next(&error) == S_OK) {
+		error->Release();
+		errors->Release();
+		return 1; // spelling issue
+	}
+
+	errors->Release();
+	return 0; // correct
 }
 
 static char**
 win8_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len, size_t* out_n_suggs)
 {
-    auto checker = static_cast<ISpellChecker*>(dict->user_data);
-    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
-    IEnumString* suggestions;
-    HRESULT hr;
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
 
-    if (!wword) {
-        *out_n_suggs = 0;
-        return nullptr;
-    }
+	if (!w_word) {
+		*out_n_suggs = 0;
+		return nullptr;
+	}
 
-    hr = checker->Suggest(wword, &suggestions);
-    g_free(wword);
+	IEnumString* suggestions;
+	HRESULT hr = checker->Suggest(w_word, &suggestions);
+	g_free(w_word);
 
-    if (FAILED(hr)) {
-        *out_n_suggs = 0;
-        return nullptr;
-    }
+	if (FAILED(hr)) {
+		*out_n_suggs = 0;
+		return nullptr;
+	}
 
-    return enumstring_to_chararray(suggestions, out_n_suggs, FALSE);
+	return enumstring_to_chararray(suggestions, out_n_suggs, FALSE);
 }
 
 /* ---------- Provider ------------ */
 
 static EnchantProviderDict*
-win8_provider_request_dict(EnchantProvider* provider, const char* const tag)
+win8_provider_request_dict(EnchantProvider* provider, const char* const xpg_tag)
 {
-    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
-    ISpellChecker* checker;
-    EnchantProviderDict* dict;
-    wchar_t* wtag = utf8_to_utf16(tag, -1, TRUE);
-    HRESULT hr;
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
-    hr = factory->CreateSpellChecker(wtag, &checker);
-    g_free(wtag);
+	char* bcp47_tag = tag_xpg_to_bcp47(xpg_tag);
+	if (!bcp47_tag) {
+		return nullptr;
+	}
 
-    if (FAILED(hr)) {
-        return nullptr;
-    }
+	LPWSTR w_bcp47_tag = (LPWSTR)g_utf8_to_utf16(bcp47_tag, -1, nullptr, nullptr, nullptr);
+	g_free(bcp47_tag);
+	if (!w_bcp47_tag) {
+		return nullptr;
+	}
 
-    dict = enchant_provider_dict_new(provider, tag);
-    dict->suggest = win8_dict_suggest;
-    dict->check = win8_dict_check;
-    dict->add_to_session = win8_dict_add_to_session;
-    dict->remove_from_session = win8_dict_remove_from_session;
+	ISpellChecker* checker;
+	HRESULT hr = factory->CreateSpellChecker(w_bcp47_tag, &checker);
+	g_free(w_bcp47_tag);
 
-    dict->user_data = checker;
+	if (FAILED(hr)) {
+		return nullptr;
+	}
 
-    return dict;
+	EnchantProviderDict* dict = enchant_provider_dict_new(provider, xpg_tag);
+	dict->user_data = checker;
+
+	dict->suggest = win8_dict_suggest;
+	dict->check = win8_dict_check;
+	dict->add_to_session = win8_dict_add_to_session;
+	dict->remove_from_session = win8_dict_remove_from_session;
+
+	return dict;
 }
 
 static void
 win8_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProviderDict* dict)
 {
-    if (dict) {
-        auto checker = static_cast<ISpellChecker*>(dict->user_data);
-        checker->Release();
-    }
+	if (dict) {
+		auto checker = static_cast<ISpellChecker*>(dict->user_data);
+		checker->Release();
+	}
 }
 
 static int
-win8_provider_dictionary_exists(EnchantProvider* provider, const char* const tag)
+win8_provider_dictionary_exists(EnchantProvider* provider, const char* const xpg_tag)
 {
-    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
-    wchar_t* wtag = utf8_to_utf16(tag, -1, TRUE);
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
-    BOOL is_supported = FALSE;
-    factory->IsSupported(wtag, &is_supported);
+	char* bcp47_tag = tag_xpg_to_bcp47(xpg_tag);
+	if (!bcp47_tag) {
+		return 0;
+	}
 
-    g_free(wtag);
-    return is_supported;
+	LPWSTR w_bcp47_tag = (LPWSTR)g_utf8_to_utf16(bcp47_tag, -1, nullptr, nullptr, nullptr);
+	g_free(bcp47_tag);
+	if (!w_bcp47_tag) {
+		return 0;
+	}
+
+	BOOL is_supported = FALSE;
+	factory->IsSupported(w_bcp47_tag, &is_supported);
+	g_free(w_bcp47_tag);
+
+	return is_supported;
 }
 
 static char**
 win8_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
 {
-    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
-    IEnumString* dicts;
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
-    if (FAILED(factory->get_SupportedLanguages(&dicts))) {
-        *out_n_dicts = 0;
-        return nullptr;
-    }
+	IEnumString* dicts;
+	if (FAILED(factory->get_SupportedLanguages(&dicts))) {
+		*out_n_dicts = 0;
+		return nullptr;
+	}
 
-    return enumstring_to_chararray(dicts, out_n_dicts, TRUE);
+	return enumstring_to_chararray(dicts, out_n_dicts, TRUE);
 }
 
 static void
 win8_provider_dispose(EnchantProvider* provider)
 {
-    if (provider) {
-        auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
-        factory->Release();
-    }
-    CoUninitialize();
+	if (provider) {
+		auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+		factory->Release();
+	}
+
+	CoUninitialize();
 }
 
 static const char*
@@ -265,35 +299,30 @@ init_enchant_provider(void);
 EnchantProvider*
 init_enchant_provider(void)
 {
-    EnchantProvider* provider;
-    ISpellCheckerFactory* factory;
+	// Initialize COM (required before using SpellCheckerFactory)
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+		// RPC_E_CHANGED_MODE means COM was already initialized with a different
+		// threading model, which is fine - we can still use it
+		return nullptr;
+	}
 
-    // Initialize COM (required before using SpellCheckerFactory)
-    HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
-        // RPC_E_CHANGED_MODE means COM was already initialized with a different
-        // threading model, which is fine - we can still use it
-        return nullptr;
-    }
+	ISpellCheckerFactory* factory;
+	if (FAILED(CoCreateInstance(__uuidof(SpellCheckerFactory), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&factory)))) {
+		CoUninitialize();
+		return nullptr;
+	}
 
-    if (FAILED(CoCreateInstance(__uuidof(SpellCheckerFactory),
-                                nullptr,
-                                CLSCTX_INPROC_SERVER,
-                                IID_PPV_ARGS(&factory)))) {
-        CoUninitialize();
-        return nullptr;
-    }
+	EnchantProvider* provider = enchant_provider_new();
+	provider->user_data = factory;
 
-    provider = enchant_provider_new();
-    provider->dispose = win8_provider_dispose;
-    provider->request_dict = win8_provider_request_dict;
-    provider->dispose_dict = win8_provider_dispose_dict;
-    provider->dictionary_exists = win8_provider_dictionary_exists;
-    provider->identify = win8_provider_identify;
-    provider->describe = win8_provider_describe;
-    provider->list_dicts = win8_provider_list_dicts;
+	provider->dispose = win8_provider_dispose;
+	provider->request_dict = win8_provider_request_dict;
+	provider->dispose_dict = win8_provider_dispose_dict;
+	provider->dictionary_exists = win8_provider_dictionary_exists;
+	provider->identify = win8_provider_identify;
+	provider->describe = win8_provider_describe;
+	provider->list_dicts = win8_provider_list_dicts;
 
-    provider->user_data = factory;
-
-    return provider;
+	return provider;
 }

--- a/providers/enchant_win8.cpp
+++ b/providers/enchant_win8.cpp
@@ -1,0 +1,299 @@
+/* MIT License
+ *
+ * Copyright (c) 2026 Moritz Mechelk
+ *
+ * HexChat
+ * Copyright (c) 2015 Patrick Griffis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include <spellcheck.h>
+
+#include "enchant-provider.h"
+
+/* --------- Utils ----------*/
+
+static char*
+utf16_to_utf8(const wchar_t* const str, gboolean from_bcp47)
+{
+    char* utf8 = g_utf16_to_utf8((gunichar2*)str, -1, nullptr, nullptr, nullptr);
+    if (utf8 && from_bcp47) {
+        char* p = utf8;
+        // bcp47 tags use syntax "en-US" while the myspell versions are "en_US"
+        while (*p) {
+            if (*p == '-')
+                *p = '_';
+            p++;
+        }
+    }
+    return utf8;
+}
+
+static wchar_t*
+utf8_to_utf16(const char* const str, gssize len, gboolean to_bcp47)
+{
+    wchar_t* utf16 = (wchar_t*)g_utf8_to_utf16(str, (glong)len, nullptr, nullptr, nullptr);
+    if (utf16 && to_bcp47) {
+        wchar_t* p = utf16;
+        // bcp47 tags use syntax "en-US" while the myspell versions are "en_US"
+        while (*p) {
+            if (*p == L'_')
+                *p = L'-';
+            p++;
+        }
+    }
+    return utf16;
+}
+
+static char**
+enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean from_bcp47)
+{
+    GArray* array = g_array_new(TRUE, FALSE, sizeof(char*));
+    LPOLESTR wstr = nullptr;
+
+    while (SUCCEEDED(strings->Next(1, &wstr, nullptr)) && wstr) {
+        char* str = utf16_to_utf8(wstr, from_bcp47);
+        if (str) {
+            g_array_append_val(array, str);
+        }
+        CoTaskMemFree(wstr);
+    }
+    strings->Release();
+
+    *out_len = array->len;
+    char** result = (char**)g_array_free(array, FALSE);
+    return result;
+}
+
+/* ---------- Dict ------------ */
+
+static void
+win8_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+    auto checker = static_cast<ISpellChecker*>(dict->user_data);
+    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+
+    if (wword) {
+        checker->Add(wword);
+        g_free(wword);
+    }
+}
+
+static void
+win8_dict_remove_from_session(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+    auto checker = static_cast<ISpellChecker*>(dict->user_data);
+
+    // try to use ISpellChecker2::Remove if available (Windows 10+)
+    ISpellChecker2* checker2 = nullptr;
+    if (SUCCEEDED(checker->QueryInterface(__uuidof(ISpellChecker2), (void**)&checker2))) {
+        wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+
+        if (wword) {
+            checker2->Remove(wword);
+            g_free(wword);
+        }
+
+        checker2->Release();
+    }
+}
+
+static int
+win8_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+    auto checker = static_cast<ISpellChecker*>(dict->user_data);
+    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+    IEnumSpellingError* errors;
+    ISpellingError* error = nullptr;
+    HRESULT hr;
+
+    if (!wword) {
+        return -1; // conversion error
+    }
+
+    hr = checker->Check(wword, &errors);
+    g_free(wword);
+
+    if (FAILED(hr)) {
+        return -1; // error
+    }
+
+    if (errors->Next(&error) == S_OK) {
+        error->Release();
+        errors->Release();
+        return 1; // spelling issue
+    }
+    
+    errors->Release();
+    return 0; // correct
+}
+
+static char**
+win8_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len, size_t* out_n_suggs)
+{
+    auto checker = static_cast<ISpellChecker*>(dict->user_data);
+    wchar_t* wword = utf8_to_utf16(word, len, FALSE);
+    IEnumString* suggestions;
+    HRESULT hr;
+
+    if (!wword) {
+        *out_n_suggs = 0;
+        return nullptr;
+    }
+
+    hr = checker->Suggest(wword, &suggestions);
+    g_free(wword);
+
+    if (FAILED(hr)) {
+        *out_n_suggs = 0;
+        return nullptr;
+    }
+
+    return enumstring_to_chararray(suggestions, out_n_suggs, FALSE);
+}
+
+/* ---------- Provider ------------ */
+
+static EnchantProviderDict*
+win8_provider_request_dict(EnchantProvider* provider, const char* const tag)
+{
+    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+    ISpellChecker* checker;
+    EnchantProviderDict* dict;
+    wchar_t* wtag = utf8_to_utf16(tag, -1, TRUE);
+    HRESULT hr;
+
+    hr = factory->CreateSpellChecker(wtag, &checker);
+    g_free(wtag);
+
+    if (FAILED(hr)) {
+        return nullptr;
+    }
+
+    dict = enchant_provider_dict_new(provider, tag);
+    dict->suggest = win8_dict_suggest;
+    dict->check = win8_dict_check;
+    dict->add_to_session = win8_dict_add_to_session;
+    dict->remove_from_session = win8_dict_remove_from_session;
+
+    dict->user_data = checker;
+
+    return dict;
+}
+
+static void
+win8_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProviderDict* dict)
+{
+    if (dict) {
+        auto checker = static_cast<ISpellChecker*>(dict->user_data);
+        checker->Release();
+    }
+}
+
+static int
+win8_provider_dictionary_exists(EnchantProvider* provider, const char* const tag)
+{
+    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+    wchar_t* wtag = utf8_to_utf16(tag, -1, TRUE);
+
+    BOOL is_supported = FALSE;
+    factory->IsSupported(wtag, &is_supported);
+
+    g_free(wtag);
+    return is_supported;
+}
+
+static char**
+win8_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
+{
+    auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+    IEnumString* dicts;
+
+    if (FAILED(factory->get_SupportedLanguages(&dicts))) {
+        *out_n_dicts = 0;
+        return nullptr;
+    }
+
+    return enumstring_to_chararray(dicts, out_n_dicts, TRUE);
+}
+
+static void
+win8_provider_dispose(EnchantProvider* provider)
+{
+    if (provider) {
+        auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+        factory->Release();
+    }
+    CoUninitialize();
+}
+
+static const char*
+win8_provider_identify(_GL_UNUSED EnchantProvider* provider)
+{
+    return "win8";
+}
+
+static const char*
+win8_provider_describe(_GL_UNUSED EnchantProvider* provider)
+{
+    return "Windows 8 SpellCheck Provider";
+}
+
+extern "C" EnchantProvider*
+init_enchant_provider(void);
+
+EnchantProvider*
+init_enchant_provider(void)
+{
+    EnchantProvider* provider;
+    ISpellCheckerFactory* factory;
+
+    // Initialize COM (required before using SpellCheckerFactory)
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        // RPC_E_CHANGED_MODE means COM was already initialized with a different
+        // threading model, which is fine - we can still use it
+        return nullptr;
+    }
+
+    if (FAILED(CoCreateInstance(__uuidof(SpellCheckerFactory),
+                                nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&factory)))) {
+        CoUninitialize();
+        return nullptr;
+    }
+
+    provider = enchant_provider_new();
+    provider->dispose = win8_provider_dispose;
+    provider->request_dict = win8_provider_request_dict;
+    provider->dispose_dict = win8_provider_dispose_dict;
+    provider->dictionary_exists = win8_provider_dictionary_exists;
+    provider->identify = win8_provider_identify;
+    provider->describe = win8_provider_describe;
+    provider->list_dicts = win8_provider_list_dicts;
+
+    provider->user_data = factory;
+
+    return provider;
+}

--- a/providers/enchant_winspell.cpp
+++ b/providers/enchant_winspell.cpp
@@ -105,7 +105,7 @@ enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean tags_fro
 /* ---------- Dict ------------ */
 
 static void
-win8_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size_t len)
+winspell_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size_t len)
 {
 	auto checker = static_cast<ISpellChecker*>(dict->user_data);
 	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
@@ -117,7 +117,7 @@ win8_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size
 }
 
 static void
-win8_dict_remove_from_session(EnchantProviderDict* dict, const char* const word, size_t len)
+winspell_dict_remove_from_session(EnchantProviderDict* dict, const char* const word, size_t len)
 {
 	auto checker = static_cast<ISpellChecker*>(dict->user_data);
 
@@ -136,7 +136,7 @@ win8_dict_remove_from_session(EnchantProviderDict* dict, const char* const word,
 }
 
 static int
-win8_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
+winspell_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
 {
 	auto checker = static_cast<ISpellChecker*>(dict->user_data);
 	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
@@ -165,7 +165,7 @@ win8_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
 }
 
 static char**
-win8_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len, size_t* out_n_suggs)
+winspell_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len, size_t* out_n_suggs)
 {
 	auto checker = static_cast<ISpellChecker*>(dict->user_data);
 	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
@@ -190,7 +190,7 @@ win8_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len,
 /* ---------- Provider ------------ */
 
 static EnchantProviderDict*
-win8_provider_request_dict(EnchantProvider* provider, const char* const xpg_tag)
+winspell_provider_request_dict(EnchantProvider* provider, const char* const xpg_tag)
 {
 	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
@@ -216,16 +216,16 @@ win8_provider_request_dict(EnchantProvider* provider, const char* const xpg_tag)
 	EnchantProviderDict* dict = enchant_provider_dict_new(provider, xpg_tag);
 	dict->user_data = checker;
 
-	dict->suggest = win8_dict_suggest;
-	dict->check = win8_dict_check;
-	dict->add_to_session = win8_dict_add_to_session;
-	dict->remove_from_session = win8_dict_remove_from_session;
+	dict->suggest = winspell_dict_suggest;
+	dict->check = winspell_dict_check;
+	dict->add_to_session = winspell_dict_add_to_session;
+	dict->remove_from_session = winspell_dict_remove_from_session;
 
 	return dict;
 }
 
 static void
-win8_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProviderDict* dict)
+winspell_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProviderDict* dict)
 {
 	if (dict) {
 		auto checker = static_cast<ISpellChecker*>(dict->user_data);
@@ -234,7 +234,7 @@ win8_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProvider
 }
 
 static int
-win8_provider_dictionary_exists(EnchantProvider* provider, const char* const xpg_tag)
+winspell_provider_dictionary_exists(EnchantProvider* provider, const char* const xpg_tag)
 {
 	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
@@ -257,7 +257,7 @@ win8_provider_dictionary_exists(EnchantProvider* provider, const char* const xpg
 }
 
 static char**
-win8_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
+winspell_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
 {
 	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
 
@@ -271,7 +271,7 @@ win8_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
 }
 
 static void
-win8_provider_dispose(EnchantProvider* provider)
+winspell_provider_dispose(EnchantProvider* provider)
 {
 	if (provider) {
 		auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
@@ -282,15 +282,15 @@ win8_provider_dispose(EnchantProvider* provider)
 }
 
 static const char*
-win8_provider_identify(_GL_UNUSED EnchantProvider* provider)
+winspell_provider_identify(_GL_UNUSED EnchantProvider* provider)
 {
-    return "win8";
+    return "winspell";
 }
 
 static const char*
-win8_provider_describe(_GL_UNUSED EnchantProvider* provider)
+winspell_provider_describe(_GL_UNUSED EnchantProvider* provider)
 {
-    return "Windows 8 SpellCheck Provider";
+    return "WinSpell Provider";
 }
 
 extern "C" EnchantProvider*
@@ -316,13 +316,13 @@ init_enchant_provider(void)
 	EnchantProvider* provider = enchant_provider_new();
 	provider->user_data = factory;
 
-	provider->dispose = win8_provider_dispose;
-	provider->request_dict = win8_provider_request_dict;
-	provider->dispose_dict = win8_provider_dispose_dict;
-	provider->dictionary_exists = win8_provider_dictionary_exists;
-	provider->identify = win8_provider_identify;
-	provider->describe = win8_provider_describe;
-	provider->list_dicts = win8_provider_list_dicts;
+	provider->dispose = winspell_provider_dispose;
+	provider->request_dict = winspell_provider_request_dict;
+	provider->dispose_dict = winspell_provider_dispose_dict;
+	provider->dictionary_exists = winspell_provider_dictionary_exists;
+	provider->identify = winspell_provider_identify;
+	provider->describe = winspell_provider_describe;
+	provider->list_dicts = winspell_provider_list_dicts;
 
 	return provider;
 }

--- a/providers/enchant_winspell.cpp
+++ b/providers/enchant_winspell.cpp
@@ -1,0 +1,328 @@
+/* Note: This file links against LGPLv3+ gnulib modules (bcp47).
+ * The combined work is thus distributed under LGPLv3+.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026 Moritz Mechelk
+ *
+ * HexChat
+ * Copyright (c) 2015 Patrick Griffis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <bcp47.h>
+#include <glib.h>
+#include <spellcheck.h>
+
+#include "enchant-provider.h"
+
+/* --------- Utils ----------*/
+
+// convert bcp47 tags (e.g. "en-US") to xpg tags (e.g. "en_US")
+static char*
+tag_bcp47_to_xpg(const char* const bcp47)
+{
+	if (!bcp47) {
+		return nullptr;
+	}
+
+	char* xpg = g_new0(char, BCP47_MAX);
+	if (!xpg) {
+		return nullptr;
+	}
+
+	bcp47_to_xpg(xpg, bcp47, nullptr);
+	return xpg;
+}
+
+// convert xpg tags (e.g. "en_US") to bcp47 tags (e.g. "en-US")
+static char*
+tag_xpg_to_bcp47(const char* const xpg)
+{
+	if (!xpg) {
+		return nullptr;
+	}
+
+	char* bcp47 = g_new0(char, BCP47_MAX);
+	if (!bcp47) {
+		return nullptr;
+	}
+
+	xpg_to_bcp47(bcp47, xpg);
+	return bcp47;
+}
+
+static char**
+enumstring_to_chararray(IEnumString* strings, size_t* out_len, gboolean tags_from_bcp47)
+{
+	GArray* array = g_array_new(TRUE, FALSE, sizeof(char*));
+
+	LPOLESTR w_str;
+	while (SUCCEEDED(strings->Next(1, &w_str, nullptr)) && w_str) {
+		char* str = g_utf16_to_utf8((gunichar2*)w_str, -1, nullptr, nullptr, nullptr);
+
+		if (str) {
+			if (tags_from_bcp47) {
+				char* xpg_tag = tag_bcp47_to_xpg(str);
+				g_free(str);
+
+				if (xpg_tag) {
+					g_array_append_val(array, xpg_tag);
+				}
+			} else {
+				g_array_append_val(array, str);
+			}
+		}
+
+		CoTaskMemFree(w_str);
+	}
+
+	strings->Release();
+
+	*out_len = array->len;
+	return (char**)g_array_free(array, FALSE);
+}
+
+/* ---------- Dict ------------ */
+
+static void
+winspell_dict_add_to_session(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
+
+	if (w_word) {
+		checker->Add(w_word);
+		g_free(w_word);
+	}
+}
+
+static void
+winspell_dict_remove_from_session(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+
+	// try to use ISpellChecker2::Remove if available (Windows 10+)
+	ISpellChecker2* checker2;
+	if (SUCCEEDED(checker->QueryInterface(__uuidof(ISpellChecker2), (void**)&checker2))) {
+		LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
+
+		if (w_word) {
+			checker2->Remove(w_word);
+			g_free(w_word);
+		}
+
+		checker2->Release();
+	}
+}
+
+static int
+winspell_dict_check(EnchantProviderDict* dict, const char* const word, size_t len)
+{
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
+
+	if (!w_word) {
+		return -1; // conversion error
+	}
+
+	IEnumSpellingError* errors;
+	HRESULT hr = checker->Check(w_word, &errors);
+	g_free(w_word);
+
+	if (FAILED(hr)) {
+		return -1; // error
+	}
+
+	ISpellingError* error;
+	if (errors->Next(&error) == S_OK) {
+		error->Release();
+		errors->Release();
+		return 1; // spelling issue
+	}
+
+	errors->Release();
+	return 0; // correct
+}
+
+static char**
+winspell_dict_suggest(EnchantProviderDict* dict, const char* const word, size_t len, size_t* out_n_suggs)
+{
+	auto checker = static_cast<ISpellChecker*>(dict->user_data);
+	LPWSTR w_word = (LPWSTR)g_utf8_to_utf16(word, (glong)len, nullptr, nullptr, nullptr);
+
+	if (!w_word) {
+		*out_n_suggs = 0;
+		return nullptr;
+	}
+
+	IEnumString* suggestions;
+	HRESULT hr = checker->Suggest(w_word, &suggestions);
+	g_free(w_word);
+
+	if (FAILED(hr)) {
+		*out_n_suggs = 0;
+		return nullptr;
+	}
+
+	return enumstring_to_chararray(suggestions, out_n_suggs, FALSE);
+}
+
+/* ---------- Provider ------------ */
+
+static EnchantProviderDict*
+winspell_provider_request_dict(EnchantProvider* provider, const char* const xpg_tag)
+{
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+
+	char* bcp47_tag = tag_xpg_to_bcp47(xpg_tag);
+	if (!bcp47_tag) {
+		return nullptr;
+	}
+
+	LPWSTR w_bcp47_tag = (LPWSTR)g_utf8_to_utf16(bcp47_tag, -1, nullptr, nullptr, nullptr);
+	g_free(bcp47_tag);
+	if (!w_bcp47_tag) {
+		return nullptr;
+	}
+
+	ISpellChecker* checker;
+	HRESULT hr = factory->CreateSpellChecker(w_bcp47_tag, &checker);
+	g_free(w_bcp47_tag);
+
+	if (FAILED(hr)) {
+		return nullptr;
+	}
+
+	EnchantProviderDict* dict = enchant_provider_dict_new(provider, xpg_tag);
+	dict->user_data = checker;
+
+	dict->suggest = winspell_dict_suggest;
+	dict->check = winspell_dict_check;
+	dict->add_to_session = winspell_dict_add_to_session;
+	dict->remove_from_session = winspell_dict_remove_from_session;
+
+	return dict;
+}
+
+static void
+winspell_provider_dispose_dict(_GL_UNUSED EnchantProvider* provider, EnchantProviderDict* dict)
+{
+	if (dict) {
+		auto checker = static_cast<ISpellChecker*>(dict->user_data);
+		checker->Release();
+	}
+}
+
+static int
+winspell_provider_dictionary_exists(EnchantProvider* provider, const char* const xpg_tag)
+{
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+
+	char* bcp47_tag = tag_xpg_to_bcp47(xpg_tag);
+	if (!bcp47_tag) {
+		return 0;
+	}
+
+	LPWSTR w_bcp47_tag = (LPWSTR)g_utf8_to_utf16(bcp47_tag, -1, nullptr, nullptr, nullptr);
+	g_free(bcp47_tag);
+	if (!w_bcp47_tag) {
+		return 0;
+	}
+
+	BOOL is_supported = FALSE;
+	factory->IsSupported(w_bcp47_tag, &is_supported);
+	g_free(w_bcp47_tag);
+
+	return is_supported;
+}
+
+static char**
+winspell_provider_list_dicts(EnchantProvider* provider, size_t* out_n_dicts)
+{
+	auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+
+	IEnumString* dicts;
+	if (FAILED(factory->get_SupportedLanguages(&dicts))) {
+		*out_n_dicts = 0;
+		return nullptr;
+	}
+
+	return enumstring_to_chararray(dicts, out_n_dicts, TRUE);
+}
+
+static void
+winspell_provider_dispose(EnchantProvider* provider)
+{
+	if (provider) {
+		auto factory = static_cast<ISpellCheckerFactory*>(provider->user_data);
+		factory->Release();
+	}
+
+	CoUninitialize();
+}
+
+static const char*
+winspell_provider_identify(_GL_UNUSED EnchantProvider* provider)
+{
+    return "winspell";
+}
+
+static const char*
+winspell_provider_describe(_GL_UNUSED EnchantProvider* provider)
+{
+    return "WinSpell Provider";
+}
+
+extern "C" EnchantProvider*
+init_enchant_provider(void);
+
+EnchantProvider*
+init_enchant_provider(void)
+{
+	// Initialize COM (required before using SpellCheckerFactory)
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+		// RPC_E_CHANGED_MODE means COM was already initialized with a different
+		// threading model, which is fine - we can still use it
+		return nullptr;
+	}
+
+	ISpellCheckerFactory* factory;
+	if (FAILED(CoCreateInstance(__uuidof(SpellCheckerFactory), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&factory)))) {
+		CoUninitialize();
+		return nullptr;
+	}
+
+	EnchantProvider* provider = enchant_provider_new();
+	provider->user_data = factory;
+
+	provider->dispose = winspell_provider_dispose;
+	provider->request_dict = winspell_provider_request_dict;
+	provider->dispose_dict = winspell_provider_dispose_dict;
+	provider->dictionary_exists = winspell_provider_dictionary_exists;
+	provider->identify = winspell_provider_identify;
+	provider->describe = winspell_provider_describe;
+	provider->list_dicts = winspell_provider_list_dicts;
+
+	return provider;
+}


### PR DESCRIPTION
This PR adds a provider for the native spellchecking added in Windows 8. Deleting words from the session (optionally) requires at least Windows 10. Closes #52.

I spent quite some time fighting the build system. The squashed changes *seem* idiomatic to me. I'd appreciate some feedback on that ;)

The CI on Windows is currently failing due to a bug in the CLI. This is fixed by the PR https://github.com/rrthomas/enchant/pull/439.

### Licensing
I'm by no means an expert at licenses, but here is the way that I see things. This should definitely be double-checked by someone other than me.

The new provider uses the `bcp47` module from gnulib to convert between BCP47 language tags (which Windows uses) and XPG/POSIX language tags (which all other providers use). This module is licensed under LGPLv3+. The source code of the provider is licensed under MIT. That makes the *whole* provider derived work and thus also LGPLv3+.

I *think* that enchant itself stays LGPLv2+, since the provider is loaded dynamically and not at all a core component.

In the process, I had to loosen the LGPL restriction of `gnulib_tool` (see https://github.com/rrthomas/enchant/pull/436/changes/4f9ac6b04add8b04b829d6617111f69e2bd7b5c5) so that it can include any LGPL licensed modules, not just LGPLv2 licensed ones. That means that we have to be more careful about the modules we use in the future. I don't know if we can somehow limit this to just the new provider. We would probably need an entirely separate build step.

### TODOs

- [x] Use a better name and description for the provider. `win8` sounds like it *only* works on Windows 8. Suggestions would be very welcome.