### PR TITLE
chore: separate LIBS for each provider

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,7 +200,8 @@ AC_DEFUN([ENCHANT_CHECK_LIB_PROVIDER],
       else
          with_[]$1=yes
          build_providers="$build_providers $1"
-         LIBS="$LIBS $5"
+         $2[]_LIBS="$5"
+         AC_SUBST([$2_LIBS])
       fi])
    AM_CONDITIONAL(WITH_[]$2, test "$with_[]$1" = yes)])
 

--- a/providers/Makefile.am
+++ b/providers/Makefile.am
@@ -24,10 +24,14 @@ AM_LDFLAGS = -module -avoid-version -no-undefined $(GLIB_LIBS) $(top_builddir)/l
 if WITH_ASPELL
 provider_LTLIBRARIES += enchant_aspell.la
 endif
+enchant_aspell_la_CFLAGS = $(AM_CFLAGS) $(ASPELL_CFLAGS)
+enchant_aspell_la_LIBADD = $(ASPELL_LIBS)
 
 if WITH_HSPELL
 provider_LTLIBRARIES += enchant_hspell.la
 endif
+enchant_hspell_la_CFLAGS = $(AM_CFLAGS) $(HSPELL_CFLAGS)
+enchant_hspell_la_LIBADD = $(HSPELL_LIBS)
 
 if WITH_HUNSPELL
 provider_LTLIBRARIES += enchant_hunspell.la
@@ -62,6 +66,7 @@ libenchant_data_DATA = AppleSpell.config
 endif
 enchant_applespell_la_LIBTOOLFLAGS = $(AM_LIBTOOLFLAGS) --tag=CXX
 enchant_applespell_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS)
+enchant_applespell_la_LIBADD = $(APPLESPELL_LIBS)
 enchant_applespell_la_SOURCES = applespell_checker.mm
 
 install-data-hook:


### PR DESCRIPTION
This PR makes all providers use their own `<NAME>_LIBS` variable instead of appending to the global `LIBS`. I think that was intended at some point, but never actually done, since most of the `<NAME>_LIBS` variables were already in-place in the provider Makefile.