### PR TITLE
fix: skip locale charset conversion if input is already UTF-8

### DIFF
--- a/src/enchant.vala
+++ b/src/enchant.vala
@@ -53,6 +53,11 @@ void print_version(FileStream to) {
 string? get_line(FileStream fin) {
 	string str = fin.read_line();
 	if (str != null && str.length > 0) {
+		/* If the string is already valid UTF-8, return it. */
+		if (str.validate())
+			return str;
+
+		/* Otherwise, try to convert from locale charset to UTF-8. */
 		try {
 			return convert(str, str.length, "UTF-8", charset);
 		} catch (ConvertError e) {


### PR DESCRIPTION
The Windows CI currently fails because the enchant CLI incorrectly assumes that all `FileStream` inputs are using the system locale encoding (which is the [ANSI code-page on Windows](https://docs.gtk.org/glib/func.get_charset.html), and UTF-8 on other systems). 

This PR makes the CLI first check if the input is already valid UTF-8 before attempting that conversion.

### TODO

Should we remove that conversion completely? It is a no-op on all platforms except Windows, and it seems like UTF-8 is the standard on Windows too.

The charset that we use (i.e. the one returned by glib) is only for file names, which seems very out of place for this use case.

> On Windows the character set returned by this function is the so-called system default ANSI code-page. That is the character set used by the “narrow” versions of C library and Win32 functions that handle file names. It might be different from the character set used by the C library’s current locale.

[Source](https://docs.gtk.org/glib/func.get_charset.html)