### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,9 @@ jobs:
     - uses: actions/checkout@v4
       with: { submodules: true }
     - name: Install dependencies
-      run: sudo apt-get -y install libglib2.0-dev libaspell-dev hspell libhunspell-dev libvoikko-dev voikko-fi aspell-en libunittest++-dev hunspell-fr groff doxygen graphviz valac pkg-config libltdl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libglib2.0-dev libaspell-dev hspell libhunspell-dev libvoikko-dev voikko-fi aspell-en libunittest++-dev hunspell-fr groff doxygen graphviz valac pkg-config libltdl-dev
     - name: Install nuspell
       run: |
         sudo apt-get -y install libicu-dev ninja-build

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   build:


### PR DESCRIPTION
- CI on Linux has been failing in the past due to the repositories being outdated. This PR fixes that by running `sudo apt-get update` before installing any packages.
- This PR adds `workflow_dispatch` as a workflow trigger, which means that you can manually start the workflow using the GitHub UI.