### PR TITLE
Fix tokenization stopping after numeric-only tokens in enchant -l

### DIFF
--- a/src/enchant.vala
+++ b/src/enchant.vala
@@ -188,7 +188,7 @@ SList<Token> tokenize_line(Dict dict, string line) {
 			}
 		}
 		if (!found_word_char) {
-			break;
+			continue;
 		}
 
 		/* Save (word, position) tuple. */


### PR DESCRIPTION
## Summary

Fix `enchant -l` so that encountering a numeric-only token does not stop processing the rest of the line.
issue: https://github.com/rrthomas/enchant/issues/437

## Problem

In `src/enchant.vala`, `tokenize_line()` checks whether a token contains at least one letter before treating it as a word.

When it encounters a token such as `1`, the token correctly fails that check. However, the current code uses `break`, which stops tokenization for the entire line instead of skipping only that token.

As a result, words after a numeric-only token are never checked.